### PR TITLE
fixed warning about deprecated 'include'

### DIFF
--- a/playbooks/roles/minishift/tasks/install_minishift_bin.yml
+++ b/playbooks/roles/minishift/tasks/install_minishift_bin.yml
@@ -35,5 +35,5 @@
     state: absent
   when: (minishift_bin.stat.exists == false or force_minishift_install|bool == true)
 
-- include: set_minishift_path.yml
+- import_tasks: set_minishift_path.yml
 

--- a/playbooks/roles/minishift/tasks/main.yml
+++ b/playbooks/roles/minishift/tasks/main.yml
@@ -8,7 +8,7 @@
   register: minishift_bin
 
 # install minishift
-- include: install_minishift_bin.yml
+- import_tasks: install_minishift_bin.yml
   when: (minishift_bin.stat.exists == false or force_minishift_install|bool == true)
 
 # set disk size and memory
@@ -35,7 +35,5 @@
   ignore_errors: yes
 
 # initialize minishift
-- include: init_minishift.yml
+- import_tasks: init_minishift.yml
   when: minishift_exist.stdout != ""
-
-

--- a/playbooks/roles/pipeline/tasks/add_scc.yml
+++ b/playbooks/roles/pipeline/tasks/add_scc.yml
@@ -28,4 +28,4 @@
   when: scc_name_file.stdout != ""
 
 # login to the cluster for the profile in use as a regular user
-- include: login_to_cluster.yml
+- import_tasks: login_to_cluster.yml

--- a/playbooks/roles/pipeline/tasks/main.yml
+++ b/playbooks/roles/pipeline/tasks/main.yml
@@ -3,7 +3,7 @@
 
 # check if the minishift cluster is started if not then start the cluster
 - name: "Startup the minishift cluster"
-  include: start_mcluster.yml
+  import_tasks: start_mcluster.yml
   when: start_minishift|bool == true
 
 # get ip of the cluster
@@ -13,27 +13,27 @@
 
 # set the oc client for the profile in use
 - name: "Set the oc client for the profile in use"
-  include: set_oc_client.yml
+  import_tasks: set_oc_client.yml
 
 # login to the cluster for the profile in use
-- include: login_to_cluster.yml
+- import_tasks: login_to_cluster.yml
 
 # create project
 - name: "Create project {{ project }}"
-  include: get_set_project.yml
+  import_tasks: get_set_project.yml
 
 # clone the pipeline repo
 - name: "Clone the pipeline repo {{ pipeline_repo }}"
-  include: clone_pipeline.yml
+  import_tasks: clone_pipeline.yml
   when: force_repo_clone|bool == true
 
-# include jq for querying container config files
+# import_tasks jq for querying container config files
 - name: Install jq for querying container config files
-  include: roles/prereqs/tasks/install_virtual_reqs.yml
+  import_tasks: roles/prereqs/tasks/install_virtual_reqs.yml
 
 # setup_jenkins_infra.yml
 - name: "Setup Jenkins master/slaves infra"
-  include: setup_jenkins_infra.yml
+  import_tasks: setup_jenkins_infra.yml
   when: setup_jenkins|bool == true
 
 # Check if Jenkins is running
@@ -44,21 +44,21 @@
 
 # setup_sample_pipelines.yml
 - name: "Setup Sample Pipelines"
-  include: setup_sample_pipelines.yml
+  import_tasks: setup_sample_pipelines.yml
   when: ((enable_sample_pipeline|bool == true) and (jenkins_running.stdout != ""))
 
 # setup_fedmsg_relay.yml
 - name: "Setup Fedmsg relay"
-  include: setup_fedmsg_relay.yml
+  import_tasks: setup_fedmsg_relay.yml
   when: setup_fedmsg|bool == true
 
 # setup_containers.yml
 - name: "Setup Pipeline containers"
-  include: setup_containers.yml
+  import_tasks: setup_containers.yml
   when: setup_containers|bool == true
 
 # add security context constraints
-- include: add_scc.yml
+- import_tasks: add_scc.yml
   when: modify_scc|bool == true
 
 # create sample pipeline

--- a/playbooks/roles/pipeline/tasks/query_setup_cluster.yml
+++ b/playbooks/roles/pipeline/tasks/query_setup_cluster.yml
@@ -87,7 +87,7 @@
 - set_fact:
     build_success: false
 
-- include: build_new_app.yml
+- import_tasks: build_new_app.yml
   with_items:
     - 1
     - 2

--- a/playbooks/roles/pipeline/tasks/setup_containers.yml
+++ b/playbooks/roles/pipeline/tasks/setup_containers.yml
@@ -5,7 +5,7 @@
   set_fact:
     container_config_name: "Pipeline containers"
 
-- include: query_setup_cluster.yml template_name={{ item }}
+- include_tasks: query_setup_cluster.yml template_name={{ item }}
   with_items: "{{ pipeline_bc_templates }}"
   when: pipeline_bc_templates != ""
 

--- a/playbooks/roles/pipeline/tasks/setup_fedmsg_relay.yml
+++ b/playbooks/roles/pipeline/tasks/setup_fedmsg_relay.yml
@@ -4,6 +4,6 @@
   set_fact:
     container_config_name: "Fedmsg relay"
 
-- include: query_setup_cluster.yml template_name={{ item }}
+- include_tasks: query_setup_cluster.yml template_name={{ item }}
   with_items: "{{ fedmsg_bc_templates }}"
   when: fedmsg_bc_templates != ""

--- a/playbooks/roles/pipeline/tasks/setup_jenkins_infra.yml
+++ b/playbooks/roles/pipeline/tasks/setup_jenkins_infra.yml
@@ -5,6 +5,6 @@
   set_fact:
     container_config_name: "Jenkins infra"
 
-- include: query_setup_cluster.yml template_name={{ item }}
+- include_tasks: query_setup_cluster.yml template_name={{ item }}
   with_items: "{{ jenkins_bc_templates }}"
   when: jenkins_bc_templates != ""

--- a/playbooks/roles/pipeline/tasks/setup_sample_pipelines.yml
+++ b/playbooks/roles/pipeline/tasks/setup_sample_pipelines.yml
@@ -5,7 +5,7 @@
   set_fact:
     container_config_name: "Sample Pipelines"
 
-- include: query_setup_cluster.yml template_name={{ item }}
+- include_tasks: query_setup_cluster.yml template_name={{ item }}
   with_items: "{{ sample_pipeline_bc_templates }}"
   when: sample_pipeline_bc_templates != ""
 

--- a/playbooks/roles/prereqs/tasks/install_kvm_plugin.yml
+++ b/playbooks/roles/prereqs/tasks/install_kvm_plugin.yml
@@ -7,7 +7,7 @@
     mode: 755
   become: true
 
-- include: install_virtual_reqs.yml
+- import_tasks: install_virtual_reqs.yml
 
 - name: Start and enable libvirtd
   service:

--- a/playbooks/roles/prereqs/tasks/main.yml
+++ b/playbooks/roles/prereqs/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for prereqs
 
 # Check if nested virtualization is enabled
-- include: nested_virt.yml
+- import_tasks: nested_virt.yml
 
 # install the kvm plugin
-- include: install_kvm_plugin.yml
+- import_tasks: install_kvm_plugin.yml


### PR DESCRIPTION
* fixed warning about deprecated:
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use 'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions. This feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
