### PR TITLE
Add a way to workaround GitHub API rate limit exceeded

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ _______
 | modify_tags                    |     Modify tags of containers                                           | modify_tags=true                                   |   true                                    | No       |
 | tag                            |     Add a tag besides latest                                            | tag=dev                                            |   "stable"                                | No       |
 | modify_scc                     |     Create/update the security context constraints                      | modify_scc=false                                   |   true                                    | No       |
+| github_token                   |     GitHub token for authenticated requests for a higher rate limit     | github_token=62e4ec8af436dc15c3ce                  |   not set                                 | No       |
 | minishift_dest_dir             |     Directory to store minishift binary                                 | minishift_dest_dir=/home/cloud-user/test           |   "{{ ansible_env.HOME }}/minishift"      | No       |
 | profile                        |     Minishift cluster profile name                                      | profile=contra-cp                                  |   "minishift"                             | No       |
 | disk_size                      |     Disk size for minishift                                             | disk_size=25gb                                     |   "40gb"                                  | No       |

--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -4,6 +4,8 @@
   become_user: '{{ become_user | default("root") }}'
   remote_user: '{{ remote_user | default("root") }}'
   gather_facts: '{{ gather_facts | default("yes") }}'
+  environment:
+    MINISHIFT_GITHUB_API_TOKEN: '{{ github_token | default("") }}'
   roles:
     - { role: prereqs, when: skip_prereqs|bool == false }
     - { role: minishift, when: setup_minishift|bool == true }


### PR DESCRIPTION
-- Checking available disk space ... 0% used OK
   Importing 'openshift/origin:v3.7.1'  CACHE MISS
   Importing 'openshift/origin-docker-registry:v3.7.1'  CACHE MISS
   Importing 'openshift/origin-haproxy-router:v3.7.1'  CACHE MISS
Error starting the cluster: Error attempting to download and cache 'oc':
Cannot get the OpenShift release version v3.7.1:
GET https://api.github.com/repos/openshift/origin/releases/tags/v3.7.1:
403 API rate limit exceeded (But here's the good news: Authenticated requests
get a higher rate limit. Check out the documentation for more details.);
rate reset in 58m42.376386176s

@see also
https://github.com/minishift/minishift/issues/1254