### PR TITLE
Use ansible module get_url for getting files

### DIFF
--- a/playbooks/roles/minishift/tasks/install_minishift_bin.yml
+++ b/playbooks/roles/minishift/tasks/install_minishift_bin.yml
@@ -5,9 +5,15 @@
   shell: curl -s https://github.com/minishift/minishift/releases/ | grep 'minishift-1.12.0-linux-amd64.*' | head -1 | sed 's/.*<a href="\(.*\)" .*/https:\/\/github.com\1/'
   register: release
 
-- name: "Pull down and extract minishift binary to {{ ansible_env.HOME }}"
+- name: "Pull down minishift binary to {{ ansible_env.HOME }}"
+  get_url:
+    url: "{{ release.stdout }}"
+    dest: "{{ ansible_env.HOME }}"
+  when: (minishift_bin.stat.exists == false or force_minishift_install|bool == true)
+
+- name: "Extract minishift binary to {{ ansible_env.HOME }}"
   unarchive:
-    src: "{{ release.stdout }}"
+    src: "{{ ansible_env.HOME }}/{{ release.stdout | basename }}"
     dest: "{{ ansible_env.HOME }}"
     remote_src: yes
   when: (minishift_bin.stat.exists == false or force_minishift_install|bool == true)

--- a/playbooks/roles/prereqs/tasks/install_virtual_reqs.yml
+++ b/playbooks/roles/prereqs/tasks/install_virtual_reqs.yml
@@ -12,6 +12,7 @@
     - libvirt
     - qemu-kvm
     - jq
+    - libselinux-python
   when: ansible_distribution == 'Fedora'
   become: true
 
@@ -41,5 +42,6 @@
     - libvirt
     - qemu-kvm
     - jq
+    - libselinux-python
   when: ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS'
   become: true


### PR DESCRIPTION
Ansible module unarchive supports extracting files from URL.
But there is not a way how to increase timeout in case of network
issues. Module get_url has default timeout 10 seconds for URL requests
and it can be changed.
    
https://github.com/ansible/ansible/issues/23864
http://docs.ansible.com/ansible/latest/unarchive_module.html
http://docs.ansible.com/ansible/latest/get_url_module.html
    
    TASK [minishift : Pull down and extract minishift binary to /root] ****
    fatal: [hp-bl465cg8-1.example.com]: FAILED! => {"changed": false,
          "msg": "Failure downloading https://github.com/minishift/minishift/releases/download/v1.12.0/minishift-1.12.0-linux-amd64.tgz,
          ('The read operation timed out',)"}
          to retry, use: --limit @/home/user/projects/contra-env-setup/playbooks/setup.retry