### PR TITLE
fixing some issues from ansible-lint in setup_pipelines.yml

### DIFF
--- a/playbooks/roles/pipeline/tasks/setup_pipelines.yml
+++ b/playbooks/roles/pipeline/tasks/setup_pipelines.yml
@@ -14,10 +14,12 @@
   register: sample_pipelines
   when: (project_repo != sample_project_repo and setup_sample_project|bool == true)
 
-- set_fact:
+- name: "Setting facts"
+  set_fact:
     all_pipelines: "{{ pipelines.files }}"
 
-- set_fact:
+- name: "Setting facts with conditional"
+  set_fact:
     all_pipelines: "{{ pipelines.files }} + {{ sample_pipelines.files }}"
   when: (project_repo != sample_project_repo and setup_sample_project|bool == true)
 
@@ -29,14 +31,15 @@
   shell: "{{ oc_bin }} get buildconfig | grep 'JenkinsPipeline' | awk '{print $1}' | egrep '^{{ item.path.split('/')[-2] }}$'"
   register: "pipeline_name_check"
   with_items: "{{ all_pipelines }}"
+  when: pipelines is defined
   ignore_errors: yes
 
 - name: "Replace pipeline buildconfigs"
-  shell: "{{ oc_bin }} replace -f {{ item.item.path }}"
+  command: "{{ oc_bin }} replace -f {{ item.item.path }}"
   with_items:  "{{ pipeline_name_check.results }}"
   when: "{{ item.rc == 0 }}"
 
 - name: "Create pipeline buildconfigs"
-  shell: "{{ oc_bin }} create -f {{ item.item.path }}"
+  command: "{{ oc_bin }} create -f {{ item.item.path }}"
   with_items:  "{{ pipeline_name_check.results }}"
   when: "{{ item.rc != 0 }}"


### PR DESCRIPTION
After running ansible-lint to setup.yml reach this issues:

[ANSIBLE0011] All tasks should be named
/home/firemanxbr/GitHub/contra-env-setup/playbooks/roles/pipeline/tasks/setup_pipelines.yml:17
Task/Handler: set_fact __file__=/home/firemanxbr/GitHub/contra-env-setup/playbooks/roles/pipeline/tasks/setup_pipelines.yml all_pipelines={{ pipelines.files }} __line__=17

[ANSIBLE0011] All tasks should be named
/home/firemanxbr/GitHub/contra-env-setup/playbooks/roles/pipeline/tasks/setup_pipelines.yml:20
Task/Handler: set_fact __file__=/home/firemanxbr/GitHub/contra-env-setup/playbooks/roles/pipeline/tasks/setup_pipelines.yml all_pipelines={{ pipelines.files }} + {{ sample_pipelines.files }} __line__=20

[ANSIBLE0012] Commands should not change things if nothing needs doing
/home/firemanxbr/GitHub/contra-env-setup/playbooks/roles/pipeline/tasks/setup_pipelines.yml:28
Task/Handler: Check if pipeline buildconfigs are present already

[ANSIBLE0013] Use shell only when shell functionality is required
/home/firemanxbr/GitHub/contra-env-setup/playbooks/roles/pipeline/tasks/setup_pipelines.yml:34
Task/Handler: Replace pipeline buildconfigs

[ANSIBLE0013] Use shell only when shell functionality is required
/home/firemanxbr/GitHub/contra-env-setup/playbooks/roles/pipeline/tasks/setup_pipelines.yml:39
Task/Handler: Create pipeline buildconfigs

Fixed in this pull request.