### PR TITLE
Increase default version of OpenShift and up memory to 8092

### DIFF
--- a/playbooks/group_vars/all/global.yml
+++ b/playbooks/group_vars/all/global.yml
@@ -29,7 +29,7 @@ profile: minishift
 
 # disk, memory size and cpus
 disk_size: 40gb
-memory: 6400mb
+memory: 8092mb
 cpus: 2
 
 # minishift iso location
@@ -65,7 +65,7 @@ modify_scc: true
 
 ## oc cli vars
 # oc version
-oc_version: v3.6.1
+oc_version: v3.9.0
 
 # Path to oc binary directory
 oc_bin_path: "{{ ansible_env.HOME }}/.{{ profile }}/cache/oc/{{ oc_version }}/linux"


### PR DESCRIPTION
- default changed for oc_version
- default changed for memory to be 8092