### PR TITLE
add start_minishift role to help users to re-start the minishift

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
     - [Example 2: Setup on a local machine :: Setup Minishift + OS templates + Jenkins 2.0 pipelines](#example-2-setup-on-a-local-machine--setup-minishift--os-templates--jenkins-20-pipelines)
     - [Example 3: Setup on a local machine :: Setup Minishift + OS templates + Jenkins 2.0 pipelines](#example-3-setup-on-a-local-machine--setup-minishift--os-templates--jenkins-20-pipelines)
     - [Example 4: Using the playbook hooks on contra-env-setup](#example-4-using-the-playbook-hooks-on-contra-env-setup)
+    - [Example 5: Re-starting the minishift](#example-5-re-starting-the-minishift)
   - [Debugging Issues](#debugging-issues)
     - [Issue #1: Can't push images to the Minishift cluster](#issue-1-cant-push-images-to-the-minishift-cluster)
       - [Solution #1:](#solution-1)
@@ -196,6 +197,15 @@ executed on contra-env-setup.
     -e setup_sample_project -K -k
     --extra-vars='{"hooks": ["/contra-env-setup/playbook_a.yml","/contra-env-setup/playbook_b.yml"]}'
 
+```
+
+### Example 5: Re-starting the minishift
+
+This a simple resource to automate the long command line to re-start the minishift.
+
+```
+    ansible-playbook -vv -i "localhost," contra-env-setup/playbooks/setup.yml \
+    -e start_minishift=true
 ```
 
 ## Debugging Issues

--- a/playbooks/group_vars/all/global.yml
+++ b/playbooks/group_vars/all/global.yml
@@ -9,6 +9,7 @@ setup_sample_project: false
 setup_playbook_hooks: false
 force_minishift_install: false
 force_repo_clone: true
+start_minishift: false
 
 # Default location to store contra-env-setup
 contra_env_setup_dir: "{{ ansible_env.HOME }}/.contra-env-setup"

--- a/playbooks/roles/start_minishift/tasks/main.yml
+++ b/playbooks/roles/start_minishift/tasks/main.yml
@@ -1,0 +1,3 @@
+# start minishift
+- name: "Initialization of minishift cluster with profile {{ profile }}"
+  shell: "{{ minishift_bin }} start --profile {{ profile }} --disk-size {{ disk_size }} --memory {{ memory }} --openshift-version {{ oc_version }} --iso-url file:///{{ minishift_dest_dir }}/minishift.iso"

--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -5,6 +5,7 @@
   remote_user: '{{ user | default("root") }}'
   gather_facts: '{{ gather_facts | default("yes") }}'
   roles:
+    - { role: start_minishift, when: start_minishift|bool == true }
     - { role: cleanup, when: run_cleanup|bool == true }
     - role: create
     - { role: prereqs, when: "run_prereqs|bool == true and setup_minishift|bool == true" }


### PR DESCRIPTION
Example to run this new role:
$ ansible-playbook -i "localhost," contra-env-setup/playbooks/setup.yml -e start_minishift=true

Will re-start the profile from globals.