### PR TITLE
Skip non template yaml files when setting up containers

### DIFF
--- a/playbooks/roles/os_temps/tasks/setup_containers.yml
+++ b/playbooks/roles/os_temps/tasks/setup_containers.yml
@@ -10,7 +10,7 @@
   find:
     paths: "{{ os_template_path }}"
     patterns: '*.yml,*.yaml'
-    contains: 'kind: Template|kind: \"Template\"'
+    contains: 'kind:\s*[\"\'']?Template[\"\'']?'
     recurse: yes
   register: os_templates
 

--- a/playbooks/roles/os_temps/tasks/setup_containers.yml
+++ b/playbooks/roles/os_temps/tasks/setup_containers.yml
@@ -10,6 +10,7 @@
   find:
     paths: "{{ os_template_path }}"
     patterns: '*.yml,*.yaml'
+    contains: 'kind: Template|kind: \"Template\"'
     recurse: yes
   register: os_templates
 


### PR DESCRIPTION
When validating and processing templates in the task file _playbooks/roles/os_temps/tasks/setup_containers.yml_, if an yaml file is not an Openshift template but a different kind of resource (e.g. SecurityContextConstraints), it should be skipped so the play doesn't fail on those steps.