### PR TITLE
Allow to use minishift > v1.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ contra-env-setup/playbooks/group_vars/all/global.yml
 
 ### Minishift setup options
 * setup_minishift: Setup a minishift cluster : default=true
-* minishift_version: Minishift version to use : default=v1.12.0
+* minishift_version: Minishift version to use : default=v1.17.0
 * minishift_dest_dir: Minishift binary and ISO directory : default={{ contra_env_setup_dir }}/minishift
 * profile: Minishift profile : default=minishift
 * disk_size: Disk size to use for minishift : default=40gb

--- a/playbooks/group_vars/all/global.yml
+++ b/playbooks/group_vars/all/global.yml
@@ -20,7 +20,7 @@ dkvm_version: v0.10.0
 
 ## minishift values
 # minishift version
-minishift_version: v1.12.0
+minishift_version: v1.17.0
 
 # default location for minishift
 minishift_dest_dir: "{{ contra_env_setup_dir }}/minishift"

--- a/playbooks/group_vars/all/global.yml
+++ b/playbooks/group_vars/all/global.yml
@@ -16,7 +16,7 @@ force_repo_clone: true
 contra_env_setup_dir: "{{ ansible_env.HOME }}/.contra-env-setup"
 
 # Docker KVM version
-dkvm_version: v0.7.0
+dkvm_version: v0.10.0
 
 ## minishift values
 # minishift version

--- a/playbooks/roles/minishift/tasks/init_minishift.yml
+++ b/playbooks/roles/minishift/tasks/init_minishift.yml
@@ -7,6 +7,9 @@
   pause:
     minutes: 3
 
+- name: Workaround for wrong SELinux context
+  shell: "{{ minishift_bin }} ssh --profile {{ profile }} -- sudo restorecon -R /var/lib/docker"
+
 - name: Stop the cluster
   shell: "{{ minishift_bin }} stop --profile {{ profile }}"
 

--- a/playbooks/roles/minishift/tasks/main.yml
+++ b/playbooks/roles/minishift/tasks/main.yml
@@ -34,11 +34,9 @@
 
 - name: "Set minishift skip-check-openshift-version"
   shell: "{{ minishift_bin }} config set skip-check-openshift-version true"
-  when: minishift_version != "v1.12.0"
 
 - name: "Set minishift skip-check-openshift-release"
   shell: "{{ minishift_bin }} config set skip-check-openshift-release true"
-  when: minishift_version != "v1.12.0"
 
 - name: "Pull down the minishift iso"
   get_url:

--- a/playbooks/roles/os_temps/tasks/start_mcluster.yml
+++ b/playbooks/roles/os_temps/tasks/start_mcluster.yml
@@ -10,3 +10,6 @@
 - name: "Start minishift profile {{ profile }}"
   shell: "{{ minishift_bin }} start --profile {{ profile }} --cpus {{ cpus }} --disk-size {{ disk_size }} --memory {{ memory }} --openshift-version {{ oc_version }} --iso-url file:///{{ minishift_dest_dir }}/minishift.iso"
   when: minishift_status.stdout == "Stopped"
+
+- name: "Workaround for wrong SELinux context"
+  shell: "{{ minishift_bin }} ssh --profile {{ profile }} -- sudo restorecon -R /var/lib/docker"


### PR DESCRIPTION
minishift v.1.13.0 change storage driver for docker from device mapper
to overlay2. And therefore it hit a bug with wrong SELinux label of files
in /var/lib/docker

This is a workaround for images which does not have the fix
https://github.com/minishift/minishift-centos-iso/issues/216
https://github.com/minishift/minishift-centos-iso/pull/217