### PR TITLE
Detect New state when querying for queued build

### DIFF
--- a/playbooks/roles/os_temps/tasks/build_new_app.yml
+++ b/playbooks/roles/os_temps/tasks/build_new_app.yml
@@ -9,7 +9,7 @@
 - name: "{{ container_config_name }} :: Wait for {{  build_config_name_file.stdout }} to be queued"
   shell: "{{ oc_bin }} get builds | grep '{{  build_config_name_file.stdout }}'"
   register: oc_build_result
-  until: oc_build_result.stdout.find(" Pending ") == -1
+  until: (oc_build_result.stdout.find(" Pending ") == -1 or oc_build_result.stdout.find(" New ") == -1)
   retries: 6
   delay: 10
   ignore_errors: yes

--- a/playbooks/roles/os_temps/tasks/setup_os_templates.yml
+++ b/playbooks/roles/os_temps/tasks/setup_os_templates.yml
@@ -108,7 +108,7 @@
 - name: "{{ container_config_name }} :: Wait for {{  build_config_name_file.stdout }} to be queued :: FINAL ATTEMPT"
   shell: "{{ oc_bin }} get builds | grep '{{  build_config_name_file.stdout }}'"
   register: oc_build_result
-  until: oc_build_result.stdout.find(" Pending ") == -1
+  until: (oc_build_result.stdout.find(" Pending ") == -1 or oc_build_result.stdout.find(" New ") == -1)
   retries: 6
   delay: 10
   ignore_errors: yes


### PR DESCRIPTION
It is possible for a build to have a New state when we query it the first time. We need to detect this and keep waiting

TASK [os_temps : debug] ********
ok: [localhost] => {
    "msg": "End result of building the container image :: jenkins-cvp-slave-1   Docker    Git@CVP-133-func-tests-3   New (CannotRetrieveServiceAccount)             "
}