### PR TITLE
Updated versions of minishift and minishift.iso

### DIFF
--- a/playbooks/group_vars/all/global.yml
+++ b/playbooks/group_vars/all/global.yml
@@ -16,11 +16,11 @@ force_repo_clone: true
 contra_env_setup_dir: "{{ ansible_env.HOME }}/.contra-env-setup"
 
 # Docker KVM version
-dkvm_version: v0.7.0
+dkvm_version: v0.10.0
 
 ## minishift values
 # minishift version
-minishift_version: v1.12.0
+minishift_version: v1.17.0
 
 # default location for minishift
 minishift_dest_dir: "{{ contra_env_setup_dir }}/minishift"
@@ -36,7 +36,7 @@ memory: 8092mb
 cpus: 2
 
 # minishift iso location
-minishift_iso: http://artifacts.ci.centos.org/fedora-atomic/minishift/iso/minishift.iso
+minishift_iso: https://s3.amazonaws.com/continuous-infra/minishift/iso/minishift.iso
 
 # Additional insecure docker registries used inside minishift
 # Use comma separated values for more registries

--- a/playbooks/roles/prereqs/tasks/install_kvm_plugin.yml
+++ b/playbooks/roles/prereqs/tasks/install_kvm_plugin.yml
@@ -2,7 +2,7 @@
 # Install the kvm plugin
 - name: Pull down kvm plugin
   get_url:
-    url: https://github.com/dhiltgen/docker-machine-kvm/releases/download/{{ dkvm_version }}/docker-machine-driver-kvm
+    url: https://github.com/dhiltgen/docker-machine-kvm/releases/download/{{ dkvm_version }}/docker-machine-driver-kvm-centos7
     dest: /usr/local/bin/docker-machine-driver-kvm
     mode: 755
   become: true


### PR DESCRIPTION
- Moved to minishift v1.17.0
- Moved to docker-md-kvm driver to v1.10.0 for CentOS
- Updated new minishift.iso and location to s3 bucket link