### PR TITLE
Log and cleanup failed builds

### DIFF
--- a/playbooks/roles/os_temps/tasks/build_new_app.yml
+++ b/playbooks/roles/os_temps/tasks/build_new_app.yml
@@ -1,9 +1,20 @@
 ---
 - name: "{{ container_config_name }} :: Imagestream and buildconfig do not exist. Creating..."
-  shell: "{{ oc_bin }} new-app {{ template_name_files[template_name] }} {{ params | join(' ') }}"
+  shell: "{{ oc_bin }} new-app {{ template_name_files[template_name] }} {{ params | join(' ') }} | sed '1,/--> Creating resources .../d;/--> Success/,$d' | grep created | sed 's/\\\"//g' | awk '{print $1\"/\"$2}'"
+  register: app_build_status
   args:
     chdir: "{{ project_dir }}/config"
   when: (image_stream_name_checks[template_name] == "" and build_config_name_checks[template_name] == "" and build_results[template_name]|bool == false)
+
+- name: "Save the created resource names"
+  set_fact:
+    created_resources: "{{ created_resources|default({}) | combine( {template_name: app_build_status.stdout_lines} ) }}"
+  when: (build_results[template_name]|bool == false and app_build_status.stdout_lines is defined)
+
+- name: "Publish created resource names"
+  debug:
+    msg: "{{ app_build_status.stdout_lines }}"
+  when: (build_results[template_name]|bool == false and app_build_status.stdout_lines is defined)
 
 # Wait container in the pipeline to start building
 - name: "{{ container_config_name }} :: Wait for {{  build_config_name_files[template_name] }} to be queued"

--- a/playbooks/roles/os_temps/tasks/build_new_app.yml
+++ b/playbooks/roles/os_temps/tasks/build_new_app.yml
@@ -20,7 +20,7 @@
 - name: "{{ container_config_name }} :: Wait for {{  build_config_name_files[template_name] }} to be queued"
   shell: "{{ oc_bin }} get builds | grep '{{  build_config_name_files[template_name] }}'"
   register: oc_build_result
-  until: oc_build_result.stdout.find(" Running ") != -1
+  until: oc_build_result.stdout.find(" Running ") != -1 or oc_build_result.stdout.find(" Failed ") != -1
   retries: 6
   delay: 10
   ignore_errors: yes

--- a/playbooks/roles/os_temps/tasks/check_new_app.yml
+++ b/playbooks/roles/os_temps/tasks/check_new_app.yml
@@ -5,7 +5,7 @@
 
 # Wait container in the pipeline to be finished building
 - name: "{{ container_config_name }} :: Wait for {{  build_config_name_files[template_name] }} to be built and marked with latest tag"
-  shell: "{{ oc_bin }} get builds | grep '{{  build_config_name_files[template_name] }}'"
+  shell: "{{ oc_bin }} get builds | grep '{{ build_config_name_files[template_name] }}'"
   register: oc_build_result
   until: (oc_build_result.stdout.find(" Running ") == -1 or oc_build_result.stdout.find(" Failed ") != -1)
   retries: 300
@@ -27,3 +27,24 @@
 - name: Modify tags on images
   shell: "{{ oc_bin }} get imagestream | awk '{print $2}' | grep -v DOCKER | sed 's/.*5000\\///g' | grep '{{ build_config_name_files[template_name] }}' | xargs -i {{ oc_bin }} tag {}:latest {}:{{ tag }}"
   when: modify_tags|bool == true and current_build_succeeded|bool == true
+
+# Output the OpenShift build logs if the current build failed
+- name: Output the OpenShift build logs if the current build failed
+  shell: "echo \"{{ oc_build_result.stdout }}\" | awk '{print $1}' | xargs -i {{ oc_bin }} logs builds/{}"
+  register: oc_build_log
+  when: build_results[template_name]|bool == false and oc_build_result.stdout is defined
+
+- name: "Publish build logs of the current failed build"
+  debug:
+    msg: "{{ oc_build_log.stdout_lines }}"
+  when: (build_results[template_name]|bool == false and oc_build_log.stdout_lines is defined)
+
+# If the build failed, cleanup all resources related to this build on the cluster
+- name: "Cleanup all resources related to this build on the cluster"
+  shell: "{{ oc_bin }} delete {{ failed_resource_name }}"
+  with_items: "{{ created_resources[template_name] }}"
+  loop_control:
+    loop_var: failed_resource_name
+  ignore_errors: yes
+  when: (build_results[template_name]|bool == false and created_resources[template_name] != "")
+

--- a/playbooks/roles/os_temps/tasks/check_new_app.yml
+++ b/playbooks/roles/os_temps/tasks/check_new_app.yml
@@ -34,9 +34,8 @@
   register: oc_build_log
   when: build_results[template_name]|bool == false and oc_build_result.stdout is defined
 
-- name: "Publish build logs of the current failed build"
-  debug:
-    msg: "{{ oc_build_log.stdout_lines }}"
+- name: "Write build logs of the current failed build to a log file"
+  copy: content="{{ oc_build_log.stdout }}" dest="/tmp/contra-env-setup/logs/run-{{ run_time }}/{{ template_name_files[template_name] }}-fail-{{ attempt_number }}.log"
   when: (build_results[template_name]|bool == false and oc_build_log.stdout_lines is defined)
 
 # If the build failed, cleanup all resources related to this build on the cluster

--- a/playbooks/roles/os_temps/tasks/handle_os_templates.yml
+++ b/playbooks/roles/os_temps/tasks/handle_os_templates.yml
@@ -19,30 +19,6 @@
     oc_check_app_status:
       stdout: ""
 
-# Check for failed apps and cleanup
-- name: "Check for all failed apps on the cluster"
-  shell: "{{ oc_bin }} get all | egrep 'Failed|Error' | egrep 'builds\\/' | awk '{print $1}' | awk -F'/' '{print $2}' | sed 's/-[0-9+]//g' "
-  register: oc_check_app_status
-  ignore_errors: yes
-  when: total_build_success|bool == false
-
-- name: "Cleanup all failed dc, bc, routes, svc, and imagestreams on the cluster"
-  shell: "{{ oc_bin }} get all | grep '{{ failed_container_name }}' | awk '{print $1}' | egrep -v 'builds\\/|po\\/' | xargs -i {{ oc_bin }} delete {}"
-  with_items: "{{ oc_check_app_status.stdout_lines }}"
-  loop_control:
-    loop_var: failed_container_name
-  ignore_errors: yes
-  when: (total_build_success|bool == false and oc_check_app_status.stdout != "")
-
-- name: "Cleanup any serviceaccounts, pvc, and rolebindings for an app if it exists on the cluster"
-  shell: "{{ oc_bin }} get {{ item }} | egrep '{{ oc_check_app_status.stdout_lines|join('|') }}' | awk '{print $1}' | xargs -i {{ oc_bin }} delete {{ item }}/{}"
-  ignore_errors: yes
-  with_items:
-    - serviceaccounts
-    - pvc
-    - rolebindings
-  when: (total_build_success|bool == false and oc_check_app_status.stdout != "")
-
 - set_fact:
     total_build_success: true
 

--- a/playbooks/roles/os_temps/tasks/handle_os_templates.yml
+++ b/playbooks/roles/os_temps/tasks/handle_os_templates.yml
@@ -16,10 +16,6 @@
     loop_var: template_filename
 
 - set_fact:
-    oc_check_app_status:
-      stdout: ""
-
-- set_fact:
     total_build_success: true
 
 # Check if all builds are marked as succesful

--- a/playbooks/roles/os_temps/tasks/main.yml
+++ b/playbooks/roles/os_temps/tasks/main.yml
@@ -1,6 +1,14 @@
 ---
 # tasks file for os_temps
 
+# Set run time to be used for logging
+- set_fact:
+    run_time: "{{ ansible_date_time.iso8601_basic_short }}"
+
+# Create directory for this run
+- name: "Create log directory"
+  file: path="/tmp/contra-env-setup/logs/run-{{ run_time }}" state=directory
+
 # Check if the minishift cluster is started if not then start the cluster
 - name: "Startup the minishift cluster"
   import_tasks: start_mcluster.yml

--- a/playbooks/roles/os_temps/tasks/setup_containers.yml
+++ b/playbooks/roles/os_temps/tasks/setup_containers.yml
@@ -70,4 +70,8 @@
     loop_var: attempt_number
   when: os_templates.files != ""
 
-
+# If there were failed builds, output the error message with log directory location
+- name: "If there were failed builds, direct user to log directory"
+  debug:
+    msg: "Some of the builds failed, check failed build logs in /tmp/contra-env-setup/logs/run-{{ run_time }}"
+  when: (total_build_success|bool == false)


### PR DESCRIPTION
This change handles the logging and cleanup of failed builds:
- Record which resources were created from the template when we run the _new-app_ command
- Clean all the recorded resources related to the template up if the build failed
- Detect if the build failed instantly (while we were waiting for it to be scheduled)
- Save logs of failed builds to log directory in _/tmp/contra-env-setup/logs/run-$timestamp/_
- If any of the builds failed, output debug message with the specific log directory location