### PR TITLE
Create new minishift profile in case it was never created before

### DIFF
--- a/playbooks/roles/minishift/tasks/main.yml
+++ b/playbooks/roles/minishift/tasks/main.yml
@@ -48,8 +48,8 @@
 
 # Check if the minishift profile exists
 - name: "Check if the minishift profile exists"
-  shell: "{{ minishift_bin }} status --profile {{ profile }} | head -1 | grep -i 'does not exist'"
-  register: minishift_exist
+  shell: "{{ minishift_bin }} status --profile {{ profile }} | head -1"
+  register: minishift_profile_status
   ignore_errors: yes
 
 # Import_tasks install_oc_bin
@@ -58,4 +58,4 @@
 
 # Initialize minishift
 - import_tasks: init_minishift.yml
-  when: minishift_exist.stdout != ""
+  when: (minishift_profile_status.stdout|lower == "does not exist") or (minishift_profile_status.rc != 0)


### PR DESCRIPTION
There are two similar cases, which both need to be covered:

  1) `minishift status --profile <name>` will return "Does not exist",
     in case someone already configured the profile with `minishift
     profile set <name>`(or in case it got deleted with `minishift delete`).

  2) `minishift status --profile <name>` will return error saying the
     profile doesn't exist at all (e.g. this is the first time it is being
     used and queried for). `minishift start` will then create that
     profile.

This change brings support for case 2), by checking the result code of
the `minishift status` call.