### PR TITLE
Fix the query command for the minishift and oc compressed binaries

### DIFF
--- a/playbooks/roles/minishift/tasks/install_minishift_bin.yml
+++ b/playbooks/roles/minishift/tasks/install_minishift_bin.yml
@@ -2,7 +2,7 @@
 # Install minishift
 
 - name: Query for minishift compressed binary
-  shell: curl -s https://github.com/minishift/minishift/releases/{{ minishift_version }} | grep 'minishift-.*-linux.*' | head -1 | sed 's/.*<a href="\(.*\)" .*/https:\/\/github.com\1/'
+  shell: curl -s https://github.com/minishift/minishift/releases/{{ minishift_version }} | grep 'minishift-.*-linux.*' | head -1 | sed 's/.*<a href="\(.*\)" .*/https:\/\/github.com\1/' | cut -d'"' -f1
   register: get_minishift_bin
 
 - name: "Pull down and extract minishift binary to {{ minishift_dest_dir }}"

--- a/playbooks/roles/os_temps/tasks/install_oc_bin.yml
+++ b/playbooks/roles/os_temps/tasks/install_oc_bin.yml
@@ -6,7 +6,7 @@
     state: directory
 
 - name: "Query for OpenShift client compressed binary version {{ oc_version }}"
-  shell: curl -s https://github.com/openshift/origin/releases/{{ oc_version }} | grep 'openshift-origin-client-tools-.*-linux.*.tar.gz' | head -1 | sed 's/.*<a href="\(.*\)" .*/https:\/\/github.com\1/'
+  shell: curl -s https://github.com/openshift/origin/releases/{{ oc_version }} | grep 'openshift-origin-client-tools-.*-linux.*.tar.gz' | head -1 | sed 's/.*<a href="\(.*\)" .*/https:\/\/github.com\1/' | cut -d'"' -f1
   register: get_oc_bin
 
 - name: "Pull down and extract OpenShift client binary(oc) to {{ contra_env_setup_dir }}"


### PR DESCRIPTION
Modified the commands which queries for the minishift and oc compressed binaries to cut off at the closing quote.
It seems the github links were updated recently, so without this change, the result of the command would be: 
"https://github.com/minishift/minishift/releases/download/v1.17.0/minishift-1.17.0-linux-amd64.tgz\" rel=\"nofollow" 
