### PR TITLE
Bump version of OpenShift from 3.9 to 3.10

### DIFF
--- a/playbooks/group_vars/all/global.yml
+++ b/playbooks/group_vars/all/global.yml
@@ -20,7 +20,7 @@ dkvm_version: v0.10.0
 
 ## minishift values
 # minishift version
-minishift_version: v1.17.0
+minishift_version: v1.23.0
 
 # default location for minishift
 minishift_dest_dir: "{{ contra_env_setup_dir }}/minishift"

--- a/playbooks/group_vars/all/global.yml
+++ b/playbooks/group_vars/all/global.yml
@@ -73,7 +73,7 @@ modify_scc: true
 
 ## oc cli vars
 # oc version
-oc_version: v3.9.0
+oc_version: v3.10.0
 
 # Path to oc binary directory
 oc_bin_path: "{{ ansible_env.HOME }}/.{{ profile }}/cache/oc/{{ oc_version }}/linux"


### PR DESCRIPTION
* The default is 3.9 but we want to move to 3.10 OpenShift