### PR TITLE
Clean out extra cruft after the url for the openshift tarball

### DIFF
--- a/playbooks/roles/os_temps/tasks/install_oc_bin.yml
+++ b/playbooks/roles/os_temps/tasks/install_oc_bin.yml
@@ -6,7 +6,7 @@
     state: directory
 
 - name: "Query for OpenShift client compressed binary version {{ oc_version }}"
-  shell: curl -s https://github.com/openshift/origin/releases/{{ oc_version }} | grep 'openshift-origin-client-tools-.*-linux.*.tar.gz' | head -1 | sed 's/.*<a href="\(.*\)" .*/https:\/\/github.com\1/'
+  shell: curl -s https://github.com/openshift/origin/releases/{{ oc_version }} | grep 'openshift-origin-client-tools-.*-linux.*.tar.gz' | head -1 | sed 's/.*<a href="\(.*\)" .*/https:\/\/github.com\1/' | sed 's/\".*//g'
   register: get_oc_bin
 
 - name: "Pull down and extract OpenShift client binary(oc) to {{ contra_env_setup_dir }}"


### PR DESCRIPTION
When using the current code to download the openshift binary, I was getting the following result, causing an error.

```
$ curl -s https://github.com/openshift/origin/releases/v3.9.0 | grep 'openshift-origin-client-tools-.*-linux.*.tar.gz' | head -1 | sed 's/.*<a href="\(.*\)" .*/https:\/\/github.com\1/'

https://github.com/openshift/origin/releases/download/v3.9.0/openshift-origin-client-tools-v3.9.0-191fece-linux-64bit.tar.gz" rel="nofollow
```
This PR cleans out the extra 'rel=nofollow' bit, ensuring the next task doesn't fail to pull down the openshift binary. If the 'rel=nofollow' bit doesn't show up, the extra sed bit does nothing.