### PR TITLE
Support the case where project does not contain a display name

### DIFF
--- a/playbooks/roles/os_temps/tasks/get_set_project.yml
+++ b/playbooks/roles/os_temps/tasks/get_set_project.yml
@@ -10,5 +10,8 @@
   shell: "{{ oc_bin }} new-project '{{ openshift_project }}' --display-name='{{ openshift_project_display_name }}'"
   when: project_query.stdout == ""
 
+- name: Set current project/namespace in the openshift cluster
+  shell: "{{ oc_bin }} project '{{ openshift_project }}'"
+
 - name: add-role-to-user
   shell: "{{ oc_bin }} policy add-role-to-user edit -z default -n '{{ openshift_project }}'"

--- a/playbooks/roles/os_temps/tasks/get_set_project.yml
+++ b/playbooks/roles/os_temps/tasks/get_set_project.yml
@@ -2,7 +2,7 @@
 # get and set the project in the openshift cluster
 
 - name: Query to see if project is already present
-  shell: "{{ oc_bin }} get project {{ openshift_project }} | grep 'Active' | awk '{print $3}'"
+  shell: "{{ oc_bin }} get project {{ openshift_project }} | grep ' Active$'"
   register: project_query
   ignore_errors: true
 


### PR DESCRIPTION
- the check for an existing project fails if project
  does not contain a description