### PR TITLE
More robust way of detecting if minishift profile exists

### DIFF
--- a/playbooks/roles/minishift/tasks/main.yml
+++ b/playbooks/roles/minishift/tasks/main.yml
@@ -48,7 +48,7 @@
 
 # Check if the minishift profile exists
 - name: "Check if the minishift profile exists"
-  shell: "{{ minishift_bin }} status --profile {{ profile }} | head -1"
+  shell: "{{ minishift_bin }} status --profile {{ profile }}"
   register: minishift_profile_status
   ignore_errors: yes
 
@@ -58,4 +58,4 @@
 
 # Initialize minishift
 - import_tasks: init_minishift.yml
-  when: (minishift_profile_status.stdout|lower == "does not exist") or (minishift_profile_status.rc != 0)
+  when: (minishift_profile_status.stdout_lines and minishift_profile_status.stdout_lines[0]|lower == "does not exist") or (minishift_profile_status.rc != 0)


### PR DESCRIPTION
The ...| head -1 was swallowing the return code from
the minishift status --profile <name>, so it was 0 every time. This
update makes sure that the return code is preserved.