### PR TITLE
setup or start minishift if true

### DIFF
--- a/playbooks/roles/pipeline/tasks/main.yml
+++ b/playbooks/roles/pipeline/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
 # tasks file for Jenkins pipelines
 
+# Check if the minishift cluster is started if not then start the cluster
+- name: "Startup the minishift cluster"
+  import_tasks: "{{ playbook_dir }}/roles/os_temps/tasks//start_mcluster.yml"
+  when: (setup_minishift|bool == true or start_minishift|bool == true)
+
 # Check if Jenkins is running
 - name: "Check to see if a Jenkins Master instance is running"
   shell: "{{ oc_bin }} get pods | grep -i 'running' | grep -i 'jenkins' | tail -1 |  awk '{print $1}'"


### PR DESCRIPTION
- If we want to skip over setting up container images
  We need to then start minishift if defined