### PR TITLE
No need to restart the VM if the config was not updated

### DIFF
--- a/playbooks/roles/minishift/tasks/init_minishift.yml
+++ b/playbooks/roles/minishift/tasks/init_minishift.yml
@@ -1,19 +1,39 @@
 ---
 # start minishift
 - name: "Initialization of minishift cluster with profile {{ profile }}"
-  shell: "{{ minishift_bin }} start --profile {{ profile }} --disk-size {{ disk_size }} --memory {{ memory }} --openshift-version {{ oc_version }} --iso-url file:///{{ minishift_dest_dir }}/minishift.iso"
+  shell: "{{ minishift_bin }} start --profile {{ profile }} --cpus {{ cpus }} --disk-size {{ disk_size }} --memory {{ memory }} --openshift-version {{ oc_version }} --iso-url file:///{{ minishift_dest_dir }}/minishift.iso"
 
-- name: Wait for the cluster to come up completely
-  pause:
-    minutes: 3
+- block:
+  - name: "Check if <cpu mode=host-passthrough/> is already set"
+    find:
+      paths: "/etc/libvirt/qemu"
+      patterns: "{{ profile }}.xml"
+      contains: '\s*<cpu.*\smode=[\"\'']host-passthrough[\"\''].*/>'
+    register: minishift_vm_config_files
+    become: yes
 
-- name: Stop the cluster
-  shell: "{{ minishift_bin }} stop --profile {{ profile }}"
+  - set_fact:
+      cpu_mode_not_configured: ((minishift_vm_config_files | default([])) | length == 0)
 
-- name: Update the VM config
-  lineinfile:
-    path: "/etc/libvirt/qemu/{{ profile }}.xml"
-    insertafter: '\s+</features>'
-    line: "  <cpu mode='host-passthrough'/>"
-  become: yes
+  - name: "Wait for the cluster to come up completely"
+    pause:
+      minutes: 3
+    when: (cpu_mode_not_configured|bool) or (start_minishift|bool == false)
+
+  - name: "Stop the minishift profile {{ profile }}"
+    shell: "{{ minishift_bin }} stop --profile {{ profile }}"
+    when: (cpu_mode_not_configured|bool) or (start_minishift|bool == false)
+
+  - name: "Update the minishift VM config"
+    lineinfile:
+      path: "/etc/libvirt/qemu/{{ profile }}.xml"
+      insertafter: '\s+</features>'
+      line: "  <cpu mode='host-passthrough'/>"
+    become: yes
+    when: cpu_mode_not_configured|bool
+
+  - name: "Start minishift profile {{ profile }} again if configured"
+    shell: "{{ minishift_bin }} start --profile {{ profile }} --cpus {{ cpus }} --disk-size {{ disk_size }} --memory {{ memory }} --openshift-version {{ oc_version }} --iso-url file:///{{ minishift_dest_dir }}/minishift.iso"
+    when: (cpu_mode_not_configured|bool) and (start_minishift|bool == true)
+
   when: host_os == "linux"

--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -8,7 +8,7 @@
     - { role: cleanup, when: run_cleanup|bool == true }
     - role: create
     - { role: prereqs, when: "run_prereqs|bool == true and setup_minishift|bool == true" }
-    - { role: minishift, when: "setup_minishift|bool == true and start_minishift == false" }
+    - { role: minishift, when: "setup_minishift|bool == true" }
     - { role: os_temps, when: setup_containers|bool == true }
     - { role: pipeline, when: setup_pipelines|bool == true }
     - { role: playbook_hooks, when: setup_playbook_hooks|bool == true }


### PR DESCRIPTION
In order to apply the cpu mode="host-passthrough" config to the VM, one needs
to stop the VM first. That was the case before, every time. However, at
least on Fedora, the cpu mode="host-passthrough" is configured by
default and thus there is no need to actually update the config and then
restart the VM. This considerably speeds up the the process.

Note about the setup_minishift and start_minishift flag values - there
are four possible cases:
  1) 'setup_minishift == true and start_minishift == true' --- this will
     result in creating and initializing brand new minishift profile, which
     will be running after the init is done.

  2) 'setup_minishift == true and start_minishift == false' --- this will
     result in creating and initializing brand new minishift profile,
     but it will be stopped at the end (as start_minishift == false).
     It may well be started again by e.g. the os_temps role which
     usually comes after the minishift role.

  3) 'setup_minishift == false and start_minishift == true' --- this
     won't initialize (create) the VM at all. The VM is expected to be
     created before running contra-env-setup. The VM will, however, be
     started at the end (in case it's not already running).

  4) 'setup_minishift == false and start_minishift == false' --- this
     won't do minishift operations at all. This combination is useful
     for deploying into remote OpenShift clusters.