### PR TITLE
Fail the run if there are failed builds, direct to log directory

### DIFF
--- a/playbooks/roles/os_temps/tasks/setup_containers.yml
+++ b/playbooks/roles/os_temps/tasks/setup_containers.yml
@@ -71,7 +71,8 @@
   when: os_templates.files != ""
 
 # If there were failed builds, output the error message with log directory location
-- name: "If there were failed builds, direct user to log directory"
-  debug:
-    msg: "Some of the builds failed, check failed build logs in /tmp/contra-env-setup/logs/run-{{ run_time }}"
+- name: "If there were failed builds, fail the run and direct user to log directory"
+  fail:
+    msg: "There were failed builds, check failed build logs in /tmp/contra-env-setup/logs/run-{{ run_time }}"
   when: (total_build_success|bool == false)
+


### PR DESCRIPTION
Fail the run if there are failed builds after going through all retries, output message directing to failed build log directory for this run.