### PR TITLE
Add setup_nested_virt option

### DIFF
--- a/playbooks/group_vars/all/global.yml
+++ b/playbooks/group_vars/all/global.yml
@@ -2,6 +2,7 @@
 # run roles based on certain params
 run_cleanup: false
 run_prereqs: true
+setup_nested_virt: true
 setup_minishift: true
 start_minishift: false
 setup_containers: true

--- a/playbooks/roles/prereqs/tasks/main.yml
+++ b/playbooks/roles/prereqs/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Linux pre reqs setup
   block:
     - import_tasks: setup_nested_virt.yml
-      when: "setup_nested_virt|bool == true"
+      when: setup_nested_virt|bool == true
     - import_tasks: install_virtual_reqs.yml
     - import_tasks: install_kvm_plugin.yml
   when: host_os == "linux"

--- a/playbooks/roles/prereqs/tasks/main.yml
+++ b/playbooks/roles/prereqs/tasks/main.yml
@@ -5,6 +5,7 @@
 - name: Linux pre reqs setup
   block:
     - import_tasks: setup_nested_virt.yml
+      when: "setup_nested_virt|bool == true"
     - import_tasks: install_virtual_reqs.yml
     - import_tasks: install_kvm_plugin.yml
   when: host_os == "linux"


### PR DESCRIPTION
Add a _setup_nested_virt_ option to _group_vars_ so we can skip the nested virtualization setup when installing prerequisites.