### PR TITLE
Add template blacklist and whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ or only certain components.  ex. minishift, jenkins infra, pipeline containers, 
 
 * run_cleanup: Run clean up of previous setup : default=false
 * run_prereqs: Run setting up virtualization and kvm-driver : default=true
+* setup_nested_virt: Run setting up of nested virtualization : default=true
 * shell_rc: Set your shell configuration file : default=.bashrc
 * contra_env_setup_dir: Directory to store the contra-env-setup :  default "{{ ansible_env.HOME }}/.contra-env-setup
 
@@ -108,6 +109,8 @@ or only certain components.  ex. minishift, jenkins infra, pipeline containers, 
 ### OpenShift s2i template setup options
 * setup_containers: Setup OpenShift s2i templates : default=true
 * os_template_dir: Relative directory in the project repo where OpenShift s2i templates are stored: default=config/s2i
+* os_template_whitelist: List of OpenShift template names which will be built exclusively (other templates will be skipped) if this list isn't empty : default=[]
+* os_template_blacklist: List of Openshift template names which will be skipped, takes precendence over the os_template_whitelist : default=[]
 * sample_os_template_dir: Relative directory in the sample project repo where OpenShift s2i templates are stored: default=config/s2i
 
 ### Jenkins 2.0 pipeline setup options

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ or only certain components.  ex. minishift, jenkins infra, pipeline containers, 
 * setup_containers: Setup OpenShift s2i templates : default=true
 * os_template_dir: Relative directory in the project repo where OpenShift s2i templates are stored: default=config/s2i
 * os_template_whitelist: List of OpenShift template names which will be built exclusively (other templates will be skipped) if this list isn't empty : default=[]
-* os_template_blacklist: List of Openshift template names which will be skipped, takes precendence over the os_template_whitelist : default=[]
+* os_template_blacklist: List of Openshift template names which will be skipped, takes precedence over the os_template_whitelist : default=[]
 * sample_os_template_dir: Relative directory in the sample project repo where OpenShift s2i templates are stored: default=config/s2i
 
 ### Jenkins 2.0 pipeline setup options

--- a/playbooks/group_vars/all/global.yml
+++ b/playbooks/group_vars/all/global.yml
@@ -99,8 +99,14 @@ project_branch: 'master'
 # Project directory
 project_dir: "{{ contra_env_setup_dir }}/{{ project_repo.split('/')[-1] | replace('.git', '') }}"
 
-# OpenSift template directory
+# OpenShift template directory
 os_template_dir: "config/s2i"
+
+# OpenShift template whitelist, not used if empty
+os_template_whitelist: []
+
+# OpenShift template blacklist, not used if whitelist is set
+os_template_blacklist: []
 
 # Jenkins pipelines directory
 pipeline_dir: "config/pipelines/buildconfigs"

--- a/playbooks/roles/os_temps/tasks/filter_templates.yml
+++ b/playbooks/roles/os_temps/tasks/filter_templates.yml
@@ -5,11 +5,11 @@
   shell: "{{ oc_bin }} process -f {{ template_file.path }} | jq '.items[1].metadata.labels.template' | sed 's/\"//g'"
   register: "template_name"
 
-- name: "Template name"
+- name: "Publish template name"
   debug:
     msg: "Template name: {{ template_name.stdout }}"
 
-- name: "Add to templates list if template name is in whitelist"
+- name: "Add to templates list if template name is in whitelist and not in blacklist"
   set_fact:
     os_template_files: "{{ os_template_files|default([]) + [ template_file ] }}"
   when: (template_name.stdout in os_template_whitelist) and ((os_template_whitelist | default([])) | length != 0) and (template_name.stdout not in os_template_blacklist)

--- a/playbooks/roles/os_temps/tasks/filter_templates.yml
+++ b/playbooks/roles/os_temps/tasks/filter_templates.yml
@@ -1,0 +1,20 @@
+---
+# Filter templates according to whitelist/blacklist rules (No filtering by default)
+
+- name: "{{ container_config_name }} :: Get template name from the yaml file"
+  shell: "{{ oc_bin }} process -f {{ template_file.path }} | jq '.items[1].metadata.labels.template' | sed 's/\"//g'"
+  register: "template_name"
+
+- name: "Template name"
+  debug:
+    msg: "Template name: {{ template_name.stdout }}"
+
+- name: "Add to templates list if template name is in whitelist"
+  set_fact:
+    os_template_files: "{{ os_template_files|default([]) + [ template_file ] }}"
+  when: (template_name.stdout in os_template_whitelist) and ((os_template_whitelist | default([])) | length != 0) and (template_name.stdout not in os_template_blacklist)
+
+- name: "Add to templates list if template name is not in blacklist and whitelist isn't set"
+  set_fact:
+    os_template_files: "{{ os_template_files|default([]) + [ template_file ] }}"
+  when: (template_name.stdout not in os_template_blacklist) and ((os_template_whitelist | default([])) | length == 0)

--- a/playbooks/roles/os_temps/tasks/handle_os_templates.yml
+++ b/playbooks/roles/os_temps/tasks/handle_os_templates.yml
@@ -2,7 +2,7 @@
 # Start builds for each container defined in the template files
 - name: "Start builds for containers defined in the template files - attempt {{ attempt_number }}"
   include_tasks: "build_new_app.yml template_name={{ template_filename.path }}.processed"
-  with_items: "{{ os_templates.files }}"
+  with_items: "{{ os_template_files }}"
   when: (total_build_success|bool == false)
   loop_control:
     loop_var: template_filename
@@ -10,7 +10,7 @@
 # Check on build status of each container, finalize if done
 - name: "Check on build status of containers, finalize if done - attempt {{ attempt_number }}"
   include_tasks: "check_new_app.yml template_name={{ template_filename.path }}.processed"
-  with_items: "{{ os_templates.files }}"
+  with_items: "{{ os_template_files }}"
   when: (total_build_success|bool == false)
   loop_control:
     loop_var: template_filename
@@ -22,6 +22,6 @@
 - name: "Check if all builds are marked as succesful"
   set_fact:
     total_build_success: "{{ total_build_success|bool and template_result.value|bool }}"
-  with_dict: "{{ build_results }}"
+  with_dict: "{{ build_results|default({}) }}"
   loop_control:
     loop_var: template_result

--- a/playbooks/roles/os_temps/tasks/setup_containers.yml
+++ b/playbooks/roles/os_temps/tasks/setup_containers.yml
@@ -4,6 +4,7 @@
 - name: "Set the container_config_name to OpenShift s2i templates"
   set_fact:
     container_config_name: "OpenShift s2i templates"
+    os_template_files: []
 
 # Use the repo's OpenShift s2i templates as the list to process
 - name: "Get OpenShift s2i template names from {{ os_template_path }}"
@@ -18,16 +19,27 @@
     msg: "{{ item.path }}"
   with_items: "{{ os_templates.files }}"
 
+- name: "Filter the templates"
+  include_tasks: "filter_templates.yml"
+  with_items: "{{ os_templates.files }}"
+  loop_control:
+    loop_var: template_file
+
+- name: "Publish templates will be built"
+  debug:
+    msg: "{{ item.path }}"
+  with_items: "{{ os_template_files }}"
+
 - name: "Process the templates"
   template:
     src: "{{ item.path }}"
     dest: "{{ item.path }}.processed"
-  with_items: "{{ os_templates.files }}"
+  with_items: "{{ os_template_files }}"
 
 # Check that templates are valid
 - name: "Check that templates are valid"
   shell: "{{ oc_bin }} process -f {{ item.path }}.processed"
-  with_items: "{{ os_templates.files }}"
+  with_items: "{{ os_template_files }}"
 
 # Set the total build success
 - set_fact:
@@ -59,8 +71,8 @@
 # Setup project_repo templates and store variables for each template
 - name: "Setup project_repo templates and store variables for each template"
   include_tasks: "setup_os_templates.yml template_name={{ item.path }}.processed"
-  with_items: "{{ os_templates.files }}"
-  when: os_templates.files != ""
+  with_items: "{{ os_template_files }}"
+  when: os_template_files != ""
 
 # Handle loading of project_repo templates into OpenShift, retry 4 times
 - name: "Handle loading of project_repo templates into OpenShift"
@@ -68,7 +80,7 @@
   with_sequence: count=4
   loop_control:
     loop_var: attempt_number
-  when: os_templates.files != ""
+  when: os_template_files != ""
 
 # If there were failed builds, output the error message with log directory location
 - name: "If there were failed builds, fail the run and direct user to log directory"

--- a/playbooks/roles/os_temps/tasks/setup_containers.yml
+++ b/playbooks/roles/os_temps/tasks/setup_containers.yml
@@ -15,7 +15,8 @@
     recurse: yes
   register: os_templates
 
-- debug:
+- name: "Publish all templates found in the directory"
+  debug:
     msg: "{{ item.path }}"
   with_items: "{{ os_templates.files }}"
 
@@ -25,7 +26,7 @@
   loop_control:
     loop_var: template_file
 
-- name: "Publish templates will be built"
+- name: "Publish templates which will be built"
   debug:
     msg: "{{ item.path }}"
   with_items: "{{ os_template_files }}"


### PR DESCRIPTION
This change adds _os_template_whitelist_ and _os_template_blacklist_ group variables (lists) that define which templates will be included/skipped according to these rules:

- All the template names in _os_template_blacklist_ will be skipped
- If _os_template_whitelist_ is defined, only the template names listed in it will be built
- If a template name shows up in both _os_template_whitelist_ and _os_template_blacklist_, it will be skipped, as the blacklist takes precedence

Both lists are empty by default, meaning that all the templates in the _os_template_dir_ will be built.