### PR TITLE
Limit testing to jenkins containers

### DIFF
--- a/test/config/Dockerfiles/contra-env-setup-test-c7/prepare_and_test.sh
+++ b/test/config/Dockerfiles/contra-env-setup-test-c7/prepare_and_test.sh
@@ -41,7 +41,7 @@ popd
 # Run the playbook locally with added hook for debugging variables needed for testing
 /usr/bin/ansible-playbook -vv -i "localhost," ${base_dir}/contra-env-setup/playbooks/setup.yml -e user=root \
                           -e ansible_connection=local -e setup_nested_virt=false -e setup_playbook_hooks=true \
-                          --extra-vars='{"hooks": ["/home/debug_vars.yml"]}'
+                          --extra-vars='{"hooks": ["/home/debug_vars.yml"], "os_template_whitelist": ["jenkins-persistent", "jenkins-contra-sample-project-slave-builder"]}'
 
 # Run tests with pytest
 python -m pytest ${base_dir}/test_contra_env_setup.py -v --junitxml=${log_dir}/contra_env_setup_centos7.xml > ${log_dir}/contra_env_setup_centos7.log

--- a/test/config/Dockerfiles/contra-env-setup-test-c7/test_contra_env_setup.py
+++ b/test/config/Dockerfiles/contra-env-setup-test-c7/test_contra_env_setup.py
@@ -5,6 +5,7 @@ import json
 import requests
 import os.path
 from subprocess import check_output
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 
 @pytest.fixture
@@ -13,7 +14,7 @@ def run_info():
     profile = None
     minishift_bin = None
     oc_bin = None
-
+    
     # Get Playbook ID from ara
     playbook_list_cmd = '/usr/bin/ara playbook list -f json'
     playbook_list = json.loads(check_output(playbook_list_cmd.split()))
@@ -33,7 +34,7 @@ def run_info():
         if result.get('Name') == 'playbook_hooks : debug-vars':
             debug_result_id = result.get('ID')
             break
-
+    
     if debug_result_id is not None:
         debug_result_cmd = '/usr/bin/ara result show %s --raw -f json' % debug_result_id
         debug_result = json.loads(check_output(debug_result_cmd.split()))
@@ -44,11 +45,11 @@ def run_info():
             oc_bin = test_run_info.get('oc_bin')
 
     return {
-        'playbook_id': playbook_id,
-        'profile': profile,
-        'minishift_bin': minishift_bin,
-        'oc_bin': oc_bin,
-    }
+               'playbook_id': playbook_id,
+               'profile': profile,
+               'minishift_bin': minishift_bin,
+               'oc_bin': oc_bin,
+           }
 
 
 def test_playbook_success(run_info):
@@ -70,7 +71,7 @@ def test_playbook_success(run_info):
             tasks_ok = stats.get('Ok')
             tasks_changed = stats.get('Changed')
             tasks_failed = stats.get('Failed')
-
+    
     assert(tasks_failed == 0)
     assert(tasks_changed > 0)
     assert(tasks_ok > 0)
@@ -79,7 +80,7 @@ def test_playbook_success(run_info):
 def test_binary_locations(run_info):
     minishift_bin = run_info.get('minishift_bin')
     oc_bin = run_info.get('oc_bin')
-
+ 
     assert(minishift_bin is not None)
     assert(os.path.isfile(minishift_bin))
     assert(oc_bin is not None)
@@ -111,16 +112,12 @@ def test_buildconfigs(run_info):
         oc_cmd = '%s get buildconfigs' % oc_bin
         oc_result = check_output(oc_cmd.split())
 
-    assert(oc_result and 'ansible-executor' in oc_result)
-    assert(oc_result and 'linchpin-executor' in oc_result)
     assert(oc_result and 'jenkins-contra-sample-project-slave' in oc_result)
     assert(oc_result and 'jenkins ' in oc_result)
 
 
 def test_builds(run_info):
     oc_bin = run_info.get('oc_bin')
-    ansible_executor_success = False
-    linchpin_executor_success = False
     jenkins_success = False
     jenkins_contra_slave_success = False
 
@@ -128,18 +125,11 @@ def test_builds(run_info):
         oc_cmd = '%s get builds' % oc_bin
         oc_result = check_output(oc_cmd.split())
         for line in oc_result.splitlines():
-            if 'ansible-executor-' in line and 'Complete' in line:
-                ansible_executor_success = True
-            if 'linchpin-executor-' in line and 'Complete' in line:
-                linchpin_executor_success = True
             if 'jenkins-' in line and 'Complete' in line and 'slave' not in line:
                 jenkins_success = True
             if 'jenkins-contra-sample-project-slave-' in line and 'Complete' in line:
                 jenkins_contra_slave_success = True
 
-
-    assert(ansible_executor_success)
-    assert(linchpin_executor_success)
     assert(jenkins_success)
     assert(jenkins_contra_slave_success)
 
@@ -152,8 +142,6 @@ def test_imagestreams(run_info):
         oc_cmd = '%s get imagestreams' % oc_bin
         oc_result = check_output(oc_cmd.split())
 
-    assert(oc_result and 'ansible-executor' in oc_result)
-    assert(oc_result and 'linchpin-executor' in oc_result)
     assert(oc_result and 'jenkins-contra-sample-project-slave' in oc_result)
     assert(oc_result and 'jenkins' in oc_result)
 
@@ -199,6 +187,7 @@ def test_jenkins_running(run_info):
         for line in oc_result.splitlines():
             if 'jenkins' in line:
                 route = line.split()[1]
+                requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
                 request = requests.get('https://%s/login' % route, verify=False)
                 jenkins_running = True if request.status_code == 200 else False
 

--- a/test/config/Dockerfiles/contra-env-setup-test-c7/test_contra_env_setup.py
+++ b/test/config/Dockerfiles/contra-env-setup-test-c7/test_contra_env_setup.py
@@ -4,6 +4,7 @@ import pytest
 import json
 import requests
 import os.path
+from time import sleep
 from subprocess import check_output
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
@@ -188,8 +189,13 @@ def test_jenkins_running(run_info):
             if 'jenkins' in line:
                 route = line.split()[1]
                 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
-                request = requests.get('https://%s/login' % route, verify=False)
-                jenkins_running = True if request.status_code == 200 else False
+                for i in range(12):
+                    request = requests.get('https://%s/login' % route, verify=False)
+                    jenkins_running = True if request.status_code == 200 else False
+
+                    if jenkins_running:
+                        break
+                    sleep(10)
 
     assert(route_exists)
     assert(jenkins_running)

--- a/test/config/Dockerfiles/contra-env-setup-test-f28/prepare_and_test.sh
+++ b/test/config/Dockerfiles/contra-env-setup-test-f28/prepare_and_test.sh
@@ -41,7 +41,7 @@ popd
 # Run the playbook locally with added hook for debugging variables needed for testing
 /usr/bin/ansible-playbook -vv -i "localhost," ${base_dir}/contra-env-setup/playbooks/setup.yml -e user=root \
                           -e ansible_connection=local -e setup_nested_virt=false -e setup_playbook_hooks=true \
-                          --extra-vars='{"hooks": ["/home/debug_vars.yml"]}'
+                          --extra-vars='{"hooks": ["/home/debug_vars.yml"], "os_template_whitelist": ["jenkins-persistent", "jenkins-contra-sample-project-slave-builder"]}'
 
 # Run tests with pytest
 python -m pytest ${base_dir}/test_contra_env_setup.py -v --junitxml=${log_dir}/contra_env_setup_fedora28.xml > ${log_dir}/contra_env_setup_fedora28.log

--- a/test/config/Dockerfiles/contra-env-setup-test-f28/test_contra_env_setup.py
+++ b/test/config/Dockerfiles/contra-env-setup-test-f28/test_contra_env_setup.py
@@ -112,16 +112,12 @@ def test_buildconfigs(run_info):
         oc_cmd = '%s get buildconfigs' % oc_bin
         oc_result = check_output(oc_cmd.split())
 
-    assert(oc_result and 'ansible-executor' in oc_result)
-    assert(oc_result and 'linchpin-executor' in oc_result)
     assert(oc_result and 'jenkins-contra-sample-project-slave' in oc_result)
     assert(oc_result and 'jenkins ' in oc_result)
 
 
 def test_builds(run_info):
     oc_bin = run_info.get('oc_bin')
-    ansible_executor_success = False
-    linchpin_executor_success = False
     jenkins_success = False
     jenkins_contra_slave_success = False
 
@@ -129,18 +125,11 @@ def test_builds(run_info):
         oc_cmd = '%s get builds' % oc_bin
         oc_result = check_output(oc_cmd.split())
         for line in oc_result.splitlines():
-            if 'ansible-executor-' in line and 'Complete' in line:
-                ansible_executor_success = True
-            if 'linchpin-executor-' in line and 'Complete' in line:
-                linchpin_executor_success = True
             if 'jenkins-' in line and 'Complete' in line and 'slave' not in line:
                 jenkins_success = True
             if 'jenkins-contra-sample-project-slave-' in line and 'Complete' in line:
                 jenkins_contra_slave_success = True
- 
 
-    assert(ansible_executor_success)
-    assert(linchpin_executor_success)
     assert(jenkins_success)
     assert(jenkins_contra_slave_success)
 
@@ -153,8 +142,6 @@ def test_imagestreams(run_info):
         oc_cmd = '%s get imagestreams' % oc_bin
         oc_result = check_output(oc_cmd.split())
 
-    assert(oc_result and 'ansible-executor' in oc_result)
-    assert(oc_result and 'linchpin-executor' in oc_result)
     assert(oc_result and 'jenkins-contra-sample-project-slave' in oc_result)
     assert(oc_result and 'jenkins' in oc_result)
 

--- a/test/config/Dockerfiles/contra-env-setup-test-f28/test_contra_env_setup.py
+++ b/test/config/Dockerfiles/contra-env-setup-test-f28/test_contra_env_setup.py
@@ -4,6 +4,7 @@ import pytest
 import json
 import requests
 import os.path
+from time import sleep
 from subprocess import check_output
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
@@ -188,8 +189,13 @@ def test_jenkins_running(run_info):
             if 'jenkins' in line:
                 route = line.split()[1]
                 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
-                request = requests.get('https://%s/login' % route, verify=False)
-                jenkins_running = True if request.status_code == 200 else False
+                for i in range(12):
+                    request = requests.get('https://%s/login' % route, verify=False)
+                    jenkins_running = True if request.status_code == 200 else False
+
+                    if jenkins_running:
+                        break
+                    sleep(10)
 
     assert(route_exists)
     assert(jenkins_running)


### PR DESCRIPTION
This change limits _contra-env-setup_ CI tests to only build and test for _jenkins_ master and slave containers. 

This prevents errors stemming from changes to the _contra-env-sample-project_ (which will have its own CI for testing all the included containers) from blocking the _contra-env-setup_ CI.

Also, now the _test_jenkins_running_ test retries getting the jenkins login page in case the service didn't start up in time for the test run.