### PR TITLE
Adjust repo cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ or only certain components.  ex. minishift, jenkins infra, pipeline containers, 
 ## Override options
 
 * force_minishift_install: Override an existing install of minishift : default=false
-* force_repo_clone: Force cloning of project repo
+* force_repo_clone: Force cloning of project repo : default=false
 
 ## Minishift and OpenShift setup options
 

--- a/playbooks/group_vars/all/global.yml
+++ b/playbooks/group_vars/all/global.yml
@@ -11,7 +11,7 @@ setup_pipelines: false
 setup_sample_project: false
 setup_playbook_hooks: false
 force_minishift_install: false
-force_repo_clone: true
+force_repo_clone: false
 
 # Default location to store contra-env-setup
 contra_env_setup_dir: "{{ ansible_env.HOME }}/.contra-env-setup"

--- a/playbooks/roles/create/tasks/clone_repos.yml
+++ b/playbooks/roles/create/tasks/clone_repos.yml
@@ -11,14 +11,14 @@
   shell: git config --global http.sslVerify false
 
 # git clone project_repo
-- name: "checkout the project repo @ {{ project_repo }} to {{ project_dir }}"
+- name: "checkout the project repo: {{ project_repo }}@{{ project_branch }} to {{ project_dir }}"
   git:
     repo: "{{ project_repo }}"
     dest: "{{ project_dir }}"
     refspec: "{{ project_refspec }}"
     version: "{{ project_branch }}"
     force: yes
-  when: ((pd_is_found.stdout is defined and pd_is_found.stdout == "")  or force_repo_clone|bool == true)
+  when: (not pd_is_found.stat.exists or force_repo_clone|bool == true)
 
 # git clone sample_project_repo
 - name: "checkout the sample project repo @ {{ sample_project_repo }} to {{ sample_project_dir }}"


### PR DESCRIPTION
Test for `pd_is_found.stat.exists` instead of incorrect `pd_is_found.stdout`
Update `force_repo_clone` to default = false in globals.yml
Update documentation to indicate `force_repo_clone default = false`