### PR TITLE
Use templates dir when building the new app

### DIFF
--- a/playbooks/roles/os_temps/tasks/build_new_app.yml
+++ b/playbooks/roles/os_temps/tasks/build_new_app.yml
@@ -3,7 +3,7 @@
   shell: "{{ oc_bin }} new-app {{ template_name_files[template_name] }} {{ params | join(' ') }} | sed '1,/--> Creating resources .../d;/--> Success/,$d' | grep created | sed 's/\\\"//g' | awk '{print $1\"/\"$2}'"
   register: app_build_status
   args:
-    chdir: "{{ project_dir }}/config"
+    chdir: "{{ project_dir }}/{{ os_template_dir.split('/')[:-1]|join('/') }}"
   when: (image_stream_name_checks[template_name] == "" and build_config_name_checks[template_name] == "" and build_results[template_name]|bool == false)
 
 - name: "Save the created resource names"


### PR DESCRIPTION
Right now, we change to the config/ directory of the project when building with _new-app_ which doesn't work when we supply an alternative _os_template_dir_ parameter, especially if the config directory doesn't exist.
This change uses the os_templates_dir when determining where to go when building the templates, moving one level up from the supplied directory.
This doesn't modify the default behavior as the default value for os_templates_dir is "_config/s2i_", so we still change to "_config_" dir when building. 