### PR TITLE
Fix include_tasks calls to work with Ansible 2.7

### DIFF
--- a/playbooks/roles/os_temps/tasks/build_new_app.yml
+++ b/playbooks/roles/os_temps/tasks/build_new_app.yml
@@ -1,4 +1,7 @@
 ---
+- set_fact:
+    template_name: "{{ template_file.path }}.processed"
+
 - name: "{{ container_config_name }} :: Imagestream and buildconfig do not exist. Creating..."
   shell: "{{ oc_bin }} new-app {{ template_name_files[template_name] }} {{ params | join(' ') }} | sed '1,/--> Creating resources .../d;/--> Success/,$d' | grep created | sed 's/\\\"//g' | awk '{print $1\"/\"$2}'"
   register: app_build_status

--- a/playbooks/roles/os_temps/tasks/check_new_app.yml
+++ b/playbooks/roles/os_temps/tasks/check_new_app.yml
@@ -2,6 +2,7 @@
 # Set current build attempt status
 - set_fact:
     current_build_succeeded: false
+    template_name: "{{ template_file.path }}.processed"
 
 # Wait container in the pipeline to be finished building
 - name: "{{ container_config_name }} :: Wait for {{  build_config_name_files[template_name] }} to be built and marked with latest tag"

--- a/playbooks/roles/os_temps/tasks/handle_os_templates.yml
+++ b/playbooks/roles/os_temps/tasks/handle_os_templates.yml
@@ -1,19 +1,19 @@
 ---
 # Start builds for each container defined in the template files
 - name: "Start builds for containers defined in the template files - attempt {{ attempt_number }}"
-  include_tasks: "build_new_app.yml template_name={{ template_filename.path }}.processed"
+  include_tasks: "build_new_app.yml"
   with_items: "{{ os_template_files }}"
   when: (total_build_success|bool == false)
   loop_control:
-    loop_var: template_filename
+    loop_var: template_file
 
 # Check on build status of each container, finalize if done
 - name: "Check on build status of containers, finalize if done - attempt {{ attempt_number }}"
-  include_tasks: "check_new_app.yml template_name={{ template_filename.path }}.processed"
+  include_tasks: "check_new_app.yml"
   with_items: "{{ os_template_files }}"
   when: (total_build_success|bool == false)
   loop_control:
-    loop_var: template_filename
+    loop_var: template_file
 
 - set_fact:
     total_build_success: true

--- a/playbooks/roles/os_temps/tasks/main.yml
+++ b/playbooks/roles/os_temps/tasks/main.yml
@@ -45,12 +45,20 @@
   import_tasks: "{{ playbook_dir }}/roles/prereqs/tasks/install_virtual_reqs.yml"
   when: (setup_minishift|bool == true and host_os == "linux")
 
-# Setup project_repo containers
-- include_tasks: "setup_containers.yml os_template_path={{ project_dir }}/{{ os_template_dir }}"
+- set_fact:
+    os_template_path: "{{ project_dir }}/{{ os_template_dir }}"
   when: setup_containers|bool == true
 
+# Setup project_repo containers
+- include_tasks: "setup_containers.yml"
+  when: setup_containers|bool == true
+
+- set_fact:
+    os_template_path: "{{ helper_project_dir }}/{{ helper_os_template_dir }}/helper PARAMS={{ SAMPLE_HELPER_PARAMS }}"
+  when: (setup_containers|bool == true and project_repo != sample_project_repo and setup_helper_containers|bool == true)
+
 # Setup sample_project_repo helper containers
-- include_tasks: "setup_containers.yml os_template_path={{ helper_project_dir }}/{{ helper_os_template_dir }}/helper PARAMS={{ SAMPLE_HELPER_PARAMS }}"
+- include_tasks: "setup_containers.yml"
   when: (setup_containers|bool == true and project_repo != sample_project_repo and setup_helper_containers|bool == true)
 
 # Check if Jenkins is running
@@ -59,12 +67,20 @@
   register: jenkins_running
   ignore_errors: yes
 
-# Setup sample_project_repo Jenkins master/slave sample containers
-- include_tasks: "setup_containers.yml os_template_path={{ sample_project_dir }}/{{ sample_os_template_dir }}/jenkins PARAMS={{ SAMPLE_JENKINS_PARAMS }}"
+- set_fact:
+    os_template_path: "{{ sample_project_dir }}/{{ sample_os_template_dir }}/jenkins PARAMS={{ SAMPLE_JENKINS_PARAMS }}"
   when: (setup_containers|bool == true and project_repo != sample_project_repo and setup_sample_project|bool == true and jenkins_running.stdout == "")
 
+# Setup sample_project_repo Jenkins master/slave sample containers
+- include_tasks: setup_containers.yml
+  when: (setup_containers|bool == true and project_repo != sample_project_repo and setup_sample_project|bool == true and jenkins_running.stdout == "")
+
+- set_fact:
+    os_template_path: "{{ sample_project_dir }}/{{ sample_os_template_dir }}/samples PARAMS={{ SAMPLE_PARAMS }}"
+  when: (setup_containers|bool == true and project_repo != sample_project_repo and setup_sample_project|bool == true)
+
 # Setup sample_project_repo sample containers
-- include_tasks: "setup_containers.yml os_template_path={{ sample_project_dir }}/{{ sample_os_template_dir }}/samples PARAMS={{ SAMPLE_PARAMS }}"
+- include_tasks: setup_containers.yml
   when: (setup_containers|bool == true and project_repo != sample_project_repo and setup_sample_project|bool == true)
 
 # Add security context constraints

--- a/playbooks/roles/os_temps/tasks/setup_containers.yml
+++ b/playbooks/roles/os_temps/tasks/setup_containers.yml
@@ -71,8 +71,10 @@
 
 # Setup project_repo templates and store variables for each template
 - name: "Setup project_repo templates and store variables for each template"
-  include_tasks: "setup_os_templates.yml template_name={{ item.path }}.processed"
+  include_tasks: "setup_os_templates.yml"
   with_items: "{{ os_template_files }}"
+  loop_control:
+    loop_var: template_file
   when: os_template_files != ""
 
 # Handle loading of project_repo templates into OpenShift, retry 4 times
@@ -88,4 +90,3 @@
   fail:
     msg: "There were failed builds, check failed build logs in /tmp/contra-env-setup/logs/run-{{ run_time }}"
   when: (total_build_success|bool == false)
-

--- a/playbooks/roles/os_temps/tasks/setup_os_templates.yml
+++ b/playbooks/roles/os_temps/tasks/setup_os_templates.yml
@@ -1,5 +1,6 @@
 ---
 - set_fact:
+    template_name: "{{ template_file.path }}.processed"
     params: []
 
 - name: "{{ container_config_name }} :: Get template name from the yaml file"
@@ -78,7 +79,3 @@
     image_stream_name_checks: "{{ image_stream_name_checks|default({}) | combine( {template_name: image_stream_name_check.stdout}) }}"
     template_name_files: "{{ template_name_files|default({}) | combine( {template_name: template_name_file.stdout}) }}"
     build_params: "{{ build_params|default({}) | combine( {template_name: params}) }}"
-
-
-
-


### PR DESCRIPTION
Since Ansible 2.7 deprecated usage of include_tasks with variables defined inline, this change sets the required variables as facts before including the tasks. 
This change is backwards compatible and has been tested on Ansible 2.4.2, 2.6.5 and 2.7.0