### PR TITLE
Use template name instead of its label when creating/filtering a new app

### DIFF
--- a/playbooks/roles/os_temps/tasks/filter_templates.yml
+++ b/playbooks/roles/os_temps/tasks/filter_templates.yml
@@ -2,7 +2,7 @@
 # Filter templates according to whitelist/blacklist rules (No filtering by default)
 
 - name: "{{ container_config_name }} :: Get template name from the yaml file"
-  shell: "{{ oc_bin }} process -f {{ template_file.path }} --output=describe | grep 'Name:' | head -n1 | awk '{print $2}'"
+  shell: "{{ oc_bin }} process -f {{ template_file.path }} --output=describe | grep \"^Name:\" | head -n1 | awk '{print $2}'"
   register: "template_name"
 
 - name: "Publish template name"

--- a/playbooks/roles/os_temps/tasks/filter_templates.yml
+++ b/playbooks/roles/os_temps/tasks/filter_templates.yml
@@ -2,7 +2,7 @@
 # Filter templates according to whitelist/blacklist rules (No filtering by default)
 
 - name: "{{ container_config_name }} :: Get template name from the yaml file"
-  shell: "{{ oc_bin }} process -f {{ template_file.path }} | jq '.items[1].metadata.labels.template' | sed 's/\"//g'"
+  shell: "{{ oc_bin }} process -f {{ template_file.path }} --output=describe | grep 'Name:' | head -n1 | awk '{print $2}'"
   register: "template_name"
 
 - name: "Publish template name"

--- a/playbooks/roles/os_temps/tasks/setup_os_templates.yml
+++ b/playbooks/roles/os_temps/tasks/setup_os_templates.yml
@@ -4,7 +4,7 @@
     params: []
 
 - name: "{{ container_config_name }} :: Get template name from the yaml file"
-  shell: "{{ oc_bin }} process -f {{ template_file.path }} --output=describe | grep 'Name:' | head -n1 | awk '{print $2}'"
+  shell: "{{ oc_bin }} process -f {{ template_file.path }} --output=describe | grep \"^Name:\" | head -n1 | awk '{print $2}'"
   register: "template_name_file"
 
 - debug:

--- a/playbooks/roles/os_temps/tasks/setup_os_templates.yml
+++ b/playbooks/roles/os_temps/tasks/setup_os_templates.yml
@@ -4,7 +4,7 @@
     params: []
 
 - name: "{{ container_config_name }} :: Get template name from the yaml file"
-  shell: "{{ oc_bin }} process -f {{ template_name }} | jq '.items[1].metadata.labels.template' | sed 's/\"//g'"
+  shell: "{{ oc_bin }} process -f {{ template_file.path }} --output=describe | grep 'Name:' | head -n1 | awk '{print $2}'"
   register: "template_name_file"
 
 - debug:


### PR DESCRIPTION
Before this change, the new-app command used template label obtained in _oc process_ json output instead of template's name since the name isn't shown in json output.
As the label doesn't have to be the same as the template's name (or exist at all), this change uses _oc process --output=describe_ command in order to obtain the template's actual name so it can be used in further commands for building and filtering available templates.