### PR TITLE
Fix - use processed s2i template to obtain its name

### DIFF
--- a/playbooks/roles/os_temps/tasks/filter_templates.yml
+++ b/playbooks/roles/os_temps/tasks/filter_templates.yml
@@ -2,7 +2,7 @@
 # Filter templates according to whitelist/blacklist rules (No filtering by default)
 
 - name: "{{ container_config_name }} :: Get template name from the yaml file"
-  shell: "{{ oc_bin }} process -f {{ template_file.path }} --output=describe | grep \"^Name:\" | head -n1 | awk '{print $2}'"
+  shell: "{{ oc_bin }} process -f {{ template_file.path }}.processed --output=describe | grep \"^Name:\" | head -n1 | awk '{print $2}'"
   register: "template_name"
 
 - name: "Publish template name"

--- a/playbooks/roles/os_temps/tasks/setup_containers.yml
+++ b/playbooks/roles/os_temps/tasks/setup_containers.yml
@@ -15,15 +15,15 @@
     recurse: yes
   register: os_templates
 
+- name: "Publish all templates found in the directory"
+  debug:
+    msg: "{{ item.path }}"
+  with_items: "{{ os_templates.files }}"
+
 - name: "Process the templates"
   template:
     src: "{{ item.path }}"
     dest: "{{ item.path }}.processed"
-  with_items: "{{ os_template_files }}"
-
-- name: "Publish all templates found in the directory"
-  debug:
-    msg: "{{ item.path }}"
   with_items: "{{ os_templates.files }}"
 
 - name: "Filter the templates"

--- a/playbooks/roles/os_temps/tasks/setup_containers.yml
+++ b/playbooks/roles/os_temps/tasks/setup_containers.yml
@@ -15,6 +15,12 @@
     recurse: yes
   register: os_templates
 
+- name: "Process the templates"
+  template:
+    src: "{{ item.path }}"
+    dest: "{{ item.path }}.processed"
+  with_items: "{{ os_template_files }}"
+
 - name: "Publish all templates found in the directory"
   debug:
     msg: "{{ item.path }}"
@@ -29,12 +35,6 @@
 - name: "Publish templates which will be built"
   debug:
     msg: "{{ item.path }}"
-  with_items: "{{ os_template_files }}"
-
-- name: "Process the templates"
-  template:
-    src: "{{ item.path }}"
-    dest: "{{ item.path }}.processed"
   with_items: "{{ os_template_files }}"
 
 # Check that templates are valid

--- a/playbooks/roles/os_temps/tasks/setup_os_templates.yml
+++ b/playbooks/roles/os_temps/tasks/setup_os_templates.yml
@@ -4,7 +4,7 @@
     params: []
 
 - name: "{{ container_config_name }} :: Get template name from the yaml file"
-  shell: "{{ oc_bin }} process -f {{ template_file.path }} --output=describe | grep \"^Name:\" | head -n1 | awk '{print $2}'"
+  shell: "{{ oc_bin }} process -f {{ template_name }} --output=describe | grep \"^Name:\" | head -n1 | awk '{print $2}'"
   register: "template_name_file"
 
 - debug:


### PR DESCRIPTION
Use processed s2i template to obtain its name instead of the base one.