### PR TITLE
Alternative OpenShift login methods

### DIFF
--- a/playbooks/group_vars/all/global.yml
+++ b/playbooks/group_vars/all/global.yml
@@ -50,6 +50,15 @@ minishift_insecure_registry: ""
 # Leave empty when using minishift
 openshift_cluster_ip: ""
 
+# Set this to true to skip the log-in step and assume it had already been done
+# manually. This is useful to avoid having to store credentials in the
+# configuration files or specifying them on the command line
+skip_login: False
+
+# cluster security token - if set to '__undefined__' the username and password
+# will be used for logging in instead
+security_token: __undefined__
+
 # cluster username
 username: developer
 

--- a/playbooks/roles/os_temps/tasks/login_to_cluster.yml
+++ b/playbooks/roles/os_temps/tasks/login_to_cluster.yml
@@ -1,4 +1,9 @@
 ---
 # login to the cluster
-- name: "Login to the Openshift cluster"
+- name: "Login to the Openshift cluster with a token"
+  command: "{{ oc_bin }} login {{ cluster_ip|quote }} --token={{ security_token|quote }} --insecure-skip-tls-verify=true"
+  when: not skip_login and security_token != '__undefined__'
+
+- name: "Login to the Openshift cluster with a username and a password"
   command: "{{ oc_bin }} login {{ cluster_ip|quote }} --username={{ username|quote }} --password={{ password|quote }} --insecure-skip-tls-verify=true"
+  when: not skip_login and security_token == '__undefined__'

--- a/playbooks/roles/os_temps/tasks/login_to_cluster.yml
+++ b/playbooks/roles/os_temps/tasks/login_to_cluster.yml
@@ -1,4 +1,4 @@
 ---
 # login to the cluster
 - name: "Login to the Openshift cluster"
-  shell: "{{ oc_bin }} login {{ cluster_ip }} --username={{ username }} --password={{ password }} --insecure-skip-tls-verify=true"
+  command: "{{ oc_bin }} login {{ cluster_ip|quote }} --username={{ username|quote }} --password={{ password|quote }} --insecure-skip-tls-verify=true"


### PR DESCRIPTION
Add support for alternative ways to login to OpenShift:
1. Support skipping the loging process and assuming the user logged-in manually via the command line
2. Support logging in with a token instead of a username and a password


Resolves part #2 and #3 of issue #104 