### PR TITLE
Fix passing parameters to OpenShift templates

### DIFF
--- a/playbooks/roles/os_temps/tasks/build_new_app.yml
+++ b/playbooks/roles/os_temps/tasks/build_new_app.yml
@@ -3,7 +3,7 @@
     template_name: "{{ template_file.path }}.processed"
 
 - name: "{{ container_config_name }} :: Imagestream and buildconfig do not exist. Creating..."
-  shell: "{{ oc_bin }} new-app {{ template_name_files[template_name] }} {{ params | join(' ') }} | sed '1,/--> Creating resources .../d;/--> Success/,$d' | grep created | sed 's/\\\"//g' | awk '{print $1\"/\"$2}'"
+  shell: "{{ oc_bin }} new-app {{ template_name_files[template_name] }} {{ build_params[template_name] | join(' ') }} | sed '1,/--> Creating resources .../d;/--> Success/,$d' | grep created | sed 's/\\\"//g' | awk '{print $1\"/\"$2}'"
   register: app_build_status
   args:
     chdir: "{{ project_dir }}/{{ os_template_dir.split('/')[:-1]|join('/') }}"


### PR DESCRIPTION
The playbook contains a lot of code that deals with and prepares parameters for passing into OpenShift templates with instantiating them.

Only it seems that the values that were prepared were not being used for some reason. This patch attempts to fix that.

Signed-off-by: Barak Korren <bkorren@redhat.com>