### PR TITLE
Enable optionally running minishift on an external VM

### DIFF
--- a/playbooks/group_vars/all/global.yml
+++ b/playbooks/group_vars/all/global.yml
@@ -50,6 +50,17 @@ minishift_insecure_registry: ""
 # Leave empty when using minishift
 openshift_cluster_ip: ""
 
+# Optionally set this to be the IP of an existing prepared VM, either local or remote
+# See https://docs.okd.io/latest/minishift/using/run-against-an-existing-machine.html
+# Leave empty when using minishift locally
+minishift_external_vm_ip: ""
+
+# Optionally set this to the external VM user with sudo privileges
+minishift_external_vm_user: ""
+
+# Optionally set this to the location of the ssh key for the external VM
+minishift_external_vm_ssh_key_location: ""
+
 # Set this to true to skip the log-in step and assume it had already been done
 # manually. This is useful to avoid having to store credentials in the
 # configuration files or specifying them on the command line

--- a/playbooks/roles/minishift/tasks/main.yml
+++ b/playbooks/roles/minishift/tasks/main.yml
@@ -43,16 +43,17 @@
   shell: "{{ minishift_bin }} config set skip-check-openshift-release true"
   when: minishift_version != "v1.12.0"
 
-# Set vm-driver to virtualbox if using a mac 
+# Set vm-driver to virtualbox if using a mac
 - name: "Set minishift vm-driver to virtualbox"
   shell: "{{ minishift_bin }} config set vm-driver virtualbox"
   when: host_os == "darwin"
 
-- name: "Pull down the minishift iso"
+- name: "Pull down the minishift iso if running minishift locally"
   get_url:
     url: "{{ minishift_iso }}"
     dest: "{{ minishift_dest_dir }}/minishift.iso"
     timeout: 120
+  when: minishift_external_vm_ip == ""
 
 - name: "Check if the minishift profile is running"
   shell: "{{ minishift_bin }} status --profile {{ profile }}"
@@ -63,6 +64,12 @@
 - name: "Get OpenShift client binary(oc) version {{ oc_version }} to {{ contra_env_setup_dir }}"
   import_tasks: "{{ playbook_dir }}/roles/os_temps/tasks/install_oc_bin.yml"
 
-# Initialize minishift
+# Initialize minishift locally
 - import_tasks: init_minishift.yml
-  when: (minishift_profile_status.stdout_lines and minishift_profile_status.stdout_lines[0]|lower == "does not exist") or (minishift_profile_status.rc != 0)
+  when: ((minishift_profile_status.stdout_lines and minishift_profile_status.stdout_lines[0]|lower == "does not exist") or (minishift_profile_status.rc != 0)) and (minishift_external_vm_ip == "")
+
+# Start minishift on an external VM if configured
+- name: "Initialization of minishift cluster with profile {{ profile }} on an existing VM ip {{ minishift_external_vm_ip }}"
+  shell: "{{ minishift_bin }} start --profile {{ profile }} --openshift-version {{ oc_version }} --vm-driver generic --remote-ipaddress {{ minishift_external_vm_ip }} --remote-ssh-user {{ minishift_external_vm_user }} --remote-ssh-key {{ minishift_external_vm_ssh_key_location }}"
+  when: ((minishift_profile_status.stdout_lines and minishift_profile_status.stdout_lines[0]|lower == "does not exist") or (minishift_profile_status.rc != 0)) and (minishift_external_vm_ip != "")
+

--- a/playbooks/roles/os_temps/tasks/start_mcluster.yml
+++ b/playbooks/roles/os_temps/tasks/start_mcluster.yml
@@ -1,12 +1,17 @@
 ---
-# check if the minishift cluster is started if not then start the cluster
+# Check if the minishift cluster is started if not then start the cluster
 
-# check if minishift is already up and running
+# Check if minishift is already up and running
 - name: "Check if the minishift profile is already up and running"
   shell: "{{ minishift_bin }} status --profile {{ profile }} | head -1 | awk '{print $2}'"
   register: minishift_status
 
-# start minishift profile
+# Start minishift profile locally
 - name: "Start minishift profile {{ profile }}"
   shell: "{{ minishift_bin }} start --profile {{ profile }} --cpus {{ cpus }} --disk-size {{ disk_size }} --memory {{ memory }} --openshift-version {{ oc_version }} --iso-url file:///{{ minishift_dest_dir }}/minishift.iso"
-  when: minishift_status.stdout == "Stopped"
+  when: minishift_status.stdout == "Stopped" and minishift_external_vm_ip == ""
+
+# Start minishift on an external VM if configured
+- name: "Start minishift profile {{ profile }} on the external VM ip {{ minishift_external_vm_ip }}"
+  shell: "{{ minishift_bin }} start --profile {{ profile }} --openshift-version {{ oc_version }} --remote-ipaddress {{ minishift_external_vm_ip }} --remote-ssh-user {{ minishift_external_vm_user }} --remote-ssh-key {{ minishift_external_vm_ssh_key_location }}"
+  when: minishift_status.stdout == "Stopped" and minishift_external_vm_ip != ""


### PR DESCRIPTION
Enable optionally running minishift on an external VM (either local or remote). The VM needs to be setup according to [these steps](https://docs.okd.io/latest/minishift/using/run-against-an-existing-machine.html) in the minishift docs.
Adds three options to the contra-env-setup:
* minishift_external_vm_ip - the IP address of the external VM
* minishift_external_vm_user - the user with the sudo privileges on the external VM
* minishift_external_vm_ssh_key_location - the location of the configured ssh key