### PR TITLE
Install only jq in os_temps task, don't install virtual requirements

### DIFF
--- a/playbooks/roles/os_temps/tasks/main.yml
+++ b/playbooks/roles/os_temps/tasks/main.yml
@@ -42,8 +42,9 @@
 
 # Import_tasks jq for querying container config files
 - name: "Install jq for querying container config files"
-  import_tasks: "{{ playbook_dir }}/roles/prereqs/tasks/install_virtual_reqs.yml"
-  when: (setup_minishift|bool == true and host_os == "linux")
+  package:
+    name: jq
+  when: (host_os == "linux")
 
 - set_fact:
     os_template_path: "{{ project_dir }}/{{ os_template_dir }}"


### PR DESCRIPTION
Install only jq in the main os_temps role, don't include the installation of other virtual requirements as that bypasses the run_prereqs option.