### PR TITLE
Use the minishift home directory for caching oc binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ modify_scc: false
 oc_version: v3.11.0
 
 # Path to oc binary directory
-oc_bin_path: "{{ ansible_env.HOME }}/.{{ profile }}/cache/oc/{{ oc_version }}/{{ host_os }}"
+oc_bin_path: "{{ ansible_env.HOME }}/.minishift/cache/oc/{{ oc_version }}/{{ host_os }}"
 
 # Path to oc binary
 oc_bin: "{{ oc_bin_path }}/oc"

--- a/playbooks/group_vars/all/global.yml
+++ b/playbooks/group_vars/all/global.yml
@@ -100,7 +100,7 @@ modify_scc: false
 oc_version: v3.11.0
 
 # Path to oc binary directory
-oc_bin_path: "{{ ansible_env.HOME }}/.{{ profile }}/cache/oc/{{ oc_version }}/{{ host_os }}"
+oc_bin_path: "{{ ansible_env.HOME }}/.minishift/cache/oc/{{ oc_version }}/{{ host_os }}"
 
 # Path to oc binary
 oc_bin: "{{ oc_bin_path }}/oc"

--- a/playbooks/roles/os_temps/tasks/install_oc_bin.yml
+++ b/playbooks/roles/os_temps/tasks/install_oc_bin.yml
@@ -2,7 +2,7 @@
 # Grab the oc client independent of minishift to talk to any Openshift cluster
 - name: "Create directory for the OpenShift client binary(oc)"
   file:
-    path: "{{ ansible_env.HOME }}/.{{ profile }}/cache/oc/{{ oc_version }}/{{ host_os }}"
+    path: "{{ oc_bin_path }}"
     state: directory
 
 - name: "Query for OpenShift client compressed binary version {{ oc_version }}"


### PR DESCRIPTION
Use the minishift home directory for caching oc binaries, as minishift uses `$MINISHIFT_HOME`  (~/.minishift) exclusively to store its cached binaries ([documentation](https://docs.okd.io/latest/minishift/using/basic-usage.html)). This should result in a minor speedup and also prevent minishift from calling the github api (also evading the dreaded rate limit) when using a non-default minishift profile.