### PR TITLE
Fix extracting ImageStream/BuildConfig from template

### DIFF
--- a/playbooks/roles/os_temps/tasks/setup_os_templates.yml
+++ b/playbooks/roles/os_temps/tasks/setup_os_templates.yml
@@ -27,7 +27,7 @@
 
 # imagestreams
 - name: "{{ container_config_name }} :: Get imagestream name from the yaml file"
-  shell: "{{ oc_bin }} process -f {{ template_name }} | jq --raw-output '.items[0].metadata.name'"
+  shell: "{{ oc_bin }} process -f {{ template_name }} | jq --raw-output '.items | map(select(.kind == \"ImageStream\")) | .[].metadata.name'"
   register: "image_stream_name_file"
 
 - name: "{{ container_config_name }} :: Get imagestream from querying the cluster"

--- a/playbooks/roles/os_temps/tasks/setup_os_templates.yml
+++ b/playbooks/roles/os_temps/tasks/setup_os_templates.yml
@@ -44,7 +44,7 @@
 
 # buildconfigs
 - name: "{{ container_config_name }} :: Get buildconfig name from the yaml file"
-  shell: "{{ oc_bin }} process -f {{ template_name }} | jq --raw-output '.items[1].metadata.name'"
+  shell: "{{ oc_bin }} process -f {{ template_name }} | jq --raw-output '.items | map(select(.kind == \"BuildConfig\")) | .[].metadata.name'"
   register: "build_config_name_file"
 
 - name: "{{ container_config_name }} :: Get buildconfig from querying the cluster"


### PR DESCRIPTION
There was an assumption that ImageStream is the 1st one in the list.
There was an assumption that BuildConfig is the 2nd one in the list.

And therefore we could get a name of wrong object.
