### PR TITLE
Fix confusing name of tasks

### DIFF
--- a/playbooks/roles/os_temps/tasks/setup_os_templates.yml
+++ b/playbooks/roles/os_temps/tasks/setup_os_templates.yml
@@ -17,11 +17,11 @@
 - debug:
     msg: "{{ container_config_name }} :: Template Name from querying the cluster: {{ template_name_check.stdout }}"
 
-- name: "{{ container_config_name }} :: Updating buildconfig {{ template_name }}"
+- name: "{{ container_config_name }} :: Updating template {{ template_name }}"
   shell: "{{ oc_bin }} replace -f {{ template_name }}"
   when: template_name_check.stdout != ""
 
-- name: "{{ container_config_name }} :: Creating buildconfig {{ template_name }}"
+- name: "{{ container_config_name }} :: Creating template {{ template_name }}"
   shell: "{{ oc_bin }} create -f {{ template_name }}"
   when: template_name_check.stdout == ""
 


### PR DESCRIPTION
Previous two tasks have names "Get template name from the yaml file",
"Get template name from querying the cluster". So we shoudl use template
also here and not buildconfig