### PR TITLE
Fix KVM driver installation: Add quotes to jinja2 var

### DIFF
--- a/playbooks/roles/prereqs/tasks/install_kvm_plugin.yml
+++ b/playbooks/roles/prereqs/tasks/install_kvm_plugin.yml
@@ -2,7 +2,7 @@
 # Install the kvm plugin
 - name: Pull down kvm plugin
   get_url:
-    url: https://github.com/dhiltgen/docker-machine-kvm/releases/download/{{ dkvm_version }}/docker-machine-driver-kvm-centos7
+    url: "https://github.com/dhiltgen/docker-machine-kvm/releases/download/{{ dkvm_version }}/docker-machine-driver-kvm-centos7"
     dest: /usr/local/bin/docker-machine-driver-kvm
     mode: 755
   become: true


### PR DESCRIPTION
This fixes KVM driver pulling step as it currently fails in local env due to jinja2 templating[1]. Adjusting this as per docs[2]
[1] - http://pastebin.test.redhat.com/704084
[2] - https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#hey-wait-a-yaml-gotcha