### PR TITLE
Adding "origin-clients" to support all required packages

### DIFF
--- a/playbooks/roles/prereqs/tasks/install_virtual_reqs.yml
+++ b/playbooks/roles/prereqs/tasks/install_virtual_reqs.yml
@@ -33,6 +33,7 @@
     name: "{{ item }}"
     state: present
   with_items:
+    - origin-clients
     - libvirt
     - qemu-kvm
     - jq


### PR DESCRIPTION
We need origin-clients package for oc binary to support newer okd versions. Also, just a good-to-have thing - I find the install_virtual_reqs name to be misleading, as these aren't just virtual pkgs