### PR TITLE
Fix the query for the oc compressed binary to search links only

### DIFF
--- a/playbooks/roles/os_temps/tasks/install_oc_bin.yml
+++ b/playbooks/roles/os_temps/tasks/install_oc_bin.yml
@@ -23,7 +23,7 @@
   when: not (oc_need_install is defined and oc_need_install|bool == false)
 
 - name: "Query for OpenShift client compressed binary version {{ oc_version }}"
-  shell: curl -s https://github.com/openshift/origin/releases/{{ oc_version }} | grep {{ client_path }} | head -1 | sed 's/.*<a href="\(.*\)" .*/https:\/\/github.com\1/' | cut -d'"' -f1
+  shell: curl -s https://github.com/openshift/origin/releases/{{ oc_version }} | grep {{ client_path }} | grep "href=" | head -1 | sed 's/.*<a href="\(.*\)" .*/https:\/\/github.com\1/' | cut -d'"' -f1
   register: get_oc_bin
   vars:
     client_path: "{% if host_os == 'darwin' %}openshift-origin-client-tools-.*-mac.*.zip{% else %}openshift-origin-client-tools-.*-linux.*.tar.gz{% endif %}"


### PR DESCRIPTION
The Release page of github has changed to include checksums for each file, so the current query gets the checksum of the file we search for instead of the hyperlink to it which breaks the setup. 
This change should fix it and make it a bit more future proof.