### PR TITLE
Add support for template overwriting

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ or only certain components.  ex. minishift, jenkins infra, pipeline containers, 
 
 * force_minishift_install: Override an existing install of minishift : default=false
 * force_repo_clone: Force cloning of project repo : default=false
+* force_template_overwrite: Force overwriting of OpenShift templates and their resources if they already exist : default=false
 
 ## Minishift and OpenShift setup options
 

--- a/playbooks/group_vars/all/global.yml
+++ b/playbooks/group_vars/all/global.yml
@@ -13,6 +13,9 @@ setup_playbook_hooks: false
 force_minishift_install: false
 force_repo_clone: false
 
+# Overwrite templates and their objects if they already exist
+force_template_overwrite: false
+
 # Use General DNS in case of VPN DNS failures
 dns_server: 8.8.8.8
 

--- a/playbooks/roles/os_temps/tasks/build_new_app.yml
+++ b/playbooks/roles/os_temps/tasks/build_new_app.yml
@@ -30,7 +30,7 @@
 - name: "{{ container_config_name }} :: Wait for {{  build_config_name_files[template_name] }} to be queued"
   shell: "{{ oc_bin }} get builds | grep '{{  build_config_name_files[template_name] }}'"
   register: oc_build_result
-  until: oc_build_result.stdout.find(" Running ") != -1 or oc_build_result.stdout.find(" Failed ") != -1
+  until: oc_build_result.stdout.find(" Running ") != -1 or oc_build_result.stdout.find(" Failed ") != -1 or oc_build_result.stdout.find(" Completed ") != -1
   retries: 6
   delay: 10
   ignore_errors: yes

--- a/playbooks/roles/os_temps/tasks/setup_os_templates.yml
+++ b/playbooks/roles/os_temps/tasks/setup_os_templates.yml
@@ -17,6 +17,18 @@
 - debug:
     msg: "{{ container_config_name }} :: Template Name from querying the cluster: {{ template_name_check.stdout }}"
 
+- name: "{{ container_config_name }} :: The template {{ template_name }} already exists, finding the label applied to all its objects"
+  shell: "{{ oc_bin }} describe templates/{{ template_name_check.stdout }} | grep \"Object Labels:\" | sed 's/Object Labels:\\s*//g' | cut -f1"
+  register: "template_label"
+  when: template_name_check.stdout != ""
+
+- name: "{{ container_config_name }} :: The template {{ template_name }} already exists, deleting all its labeled objects so they can be recreated"
+  shell: "{{ oc_bin }} delete all -l {{ template_label.stdout }}"
+  when:
+    - template_name_check.stdout != ""
+    - template_label.stdout != ""
+    - force_template_overwrite|bool == true
+
 - name: "{{ container_config_name }} :: Updating template {{ template_name }}"
   shell: "{{ oc_bin }} replace -f {{ template_name }}"
   when: template_name_check.stdout != ""


### PR DESCRIPTION
Add the `force_template_overwrite` flag that allows us to delete all resources belonging to templates we want to replace on the existing cluster so we can build those templates from scratch. 
Works well in combination with template whitelist/blacklist.