### PR TITLE
When checking the status of container builds always check the latest one

### DIFF
--- a/playbooks/roles/os_temps/tasks/build_new_app.yml
+++ b/playbooks/roles/os_temps/tasks/build_new_app.yml
@@ -28,7 +28,7 @@
 
 # Wait container in the pipeline to start building
 - name: "{{ container_config_name }} :: Wait for {{  build_config_name_files[template_name] }} to be queued"
-  shell: "{{ oc_bin }} get builds | grep '{{  build_config_name_files[template_name] }}' | sort -V | tail -n 1"
+  shell: "{{ oc_bin }} get builds | egrep \"{{ build_config_name_files[template_name] }}-[0-9]*\\s\" | sort -V | tail -n 1"
   register: oc_build_result
   until: oc_build_result.stdout.find(" Running ") != -1 or oc_build_result.stdout.find(" Failed ") != -1
   retries: 6

--- a/playbooks/roles/os_temps/tasks/build_new_app.yml
+++ b/playbooks/roles/os_temps/tasks/build_new_app.yml
@@ -28,7 +28,7 @@
 
 # Wait container in the pipeline to start building
 - name: "{{ container_config_name }} :: Wait for {{  build_config_name_files[template_name] }} to be queued"
-  shell: "{{ oc_bin }} get builds | grep '{{  build_config_name_files[template_name] }}'"
+  shell: "{{ oc_bin }} get builds | grep '{{  build_config_name_files[template_name] }}' | sort -V | tail -n 1"
   register: oc_build_result
   until: oc_build_result.stdout.find(" Running ") != -1 or oc_build_result.stdout.find(" Failed ") != -1
   retries: 6

--- a/playbooks/roles/os_temps/tasks/check_new_app.yml
+++ b/playbooks/roles/os_temps/tasks/check_new_app.yml
@@ -6,7 +6,7 @@
 
 # Wait container in the pipeline to be finished building
 - name: "{{ container_config_name }} :: Wait for {{  build_config_name_files[template_name] }} to be built and marked with latest tag"
-  shell: "{{ oc_bin }} get builds | grep '{{ build_config_name_files[template_name] }}'"
+  shell: "{{ oc_bin }} get builds | grep '{{ build_config_name_files[template_name] }}' | sort -V | tail -n 1"
   register: oc_build_result
   until: (oc_build_result.stdout.find(" Running ") == -1 or oc_build_result.stdout.find(" Failed ") != -1)
   retries: 300

--- a/playbooks/roles/os_temps/tasks/check_new_app.yml
+++ b/playbooks/roles/os_temps/tasks/check_new_app.yml
@@ -6,7 +6,7 @@
 
 # Wait container in the pipeline to be finished building
 - name: "{{ container_config_name }} :: Wait for {{  build_config_name_files[template_name] }} to be built and marked with latest tag"
-  shell: "{{ oc_bin }} get builds | grep '{{ build_config_name_files[template_name] }}' | sort -V | tail -n 1"
+  shell: "{{ oc_bin }} get builds | egrep \"{{ build_config_name_files[template_name] }}-[0-9]*\\s\" | sort -V | tail -n 1"
   register: oc_build_result
   until: (oc_build_result.stdout.find(" Running ") == -1 or oc_build_result.stdout.find(" Failed ") != -1)
   retries: 300


### PR DESCRIPTION
When checking the status of container builds always check the latest one.
Especially important when rebuilding failed builds or updating existing ones.