### PR TITLE
ADD conditions to install proper pkgs in Fedora 30

### DIFF
--- a/playbooks/roles/prereqs/tasks/install_virtual_reqs.yml
+++ b/playbooks/roles/prereqs/tasks/install_virtual_reqs.yml
@@ -1,7 +1,12 @@
 
-- name: Install pre-requesites for dnf support for Fedora
+- name: Install pre-requesites for dnf support for Fedora 29 and below
   raw: dnf install -y --allowerasing python-dnf
-  when: ansible_distribution == 'Fedora'
+  when: ansible_distribution == 'Fedora' and ansible_distribution_version|int <= 29
+  become: true
+
+- name: Install pre-requesites for dnf support for Fedora 30 and above
+  raw: dnf install -y --allowerasing python3-dnf
+  when: ansible_distribution == 'Fedora' and ansible_distribution_version|int >= 30
   become: true
 
 - name: Check if EPEL is installed for non Fedora distros
@@ -39,3 +44,30 @@
     - libselinux-python
     - git
   become: true
+  when: not ansible_distribution == 'Fedora'
+
+- name: "Install libvirt, qemu-kvm, and jq on {{ ansible_distribution }} version 29 or below"
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - libvirt
+    - qemu-kvm
+    - jq
+    - libselinux-python
+    - git
+  become: true
+  when: ansible_distribution == 'Fedora' and ansible_distribution_major_version|int <= 29
+
+- name: "Install libvirt, qemu-kvm, and jq on {{ ansible_distribution }} version 30 or above"
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - libvirt
+    - qemu-kvm
+    - jq
+    - python3-libselinux
+    - git
+  become: true
+  when: ansible_distribution == 'Fedora' and ansible_distribution_major_version|int >= 30


### PR DESCRIPTION
Added conditionals to install python3-libselinux and python3-dnf when
the version of Fedora is greater than 30.

This resolves #158 