### PR TITLE
Automate provisioning OpenStack instance manually

### DIFF
--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -1,0 +1,18 @@
+# Automate Provisioning OpenStack Instance 
+
+- The Ansible playbook will automate the creation of an openstack instance.
+- The playbook contains the neccessary parameters to create the instance. 
+- The parameters include: image, key_name, flavor, network, and security_groups
+- The parameters image, flavor, network, and security groups must be passed in the command line as extra-vars when running the playbook.
+
+### Steps to Create the OS Instance
+1. Run the following commands to set up the OpenStack credentials:  
+**export OS_AUTH_URL= < url-to-openstack-identity > #you can get this url from OS VM  
+export OS_PROJECT_NAME= < project-name >   
+export OS_USER_DOMAIN_NAME= < domain-name > *# (optional)*  
+export OS_PROJECT_DOMAIN_ID= < domain-ID > *# (optional)*  
+export OS_USERNAME= < user-name >  
+export OS_PASSWORD= < password >  # *(optional)***  
+
+2. Run the playbook with the following command and provide the parameters as extra-vars:   
+**ansible-playbook -vv -i "localhost," --connection=local provision_openstack_instance.yml -e "vm_name=< give a name for the VM > image=< image name > flavor=< flavor name > network=< network name > sec_groups= < security groups name >"** 

--- a/playbooks/provision_openstack_instance.yml
+++ b/playbooks/provision_openstack_instance.yml
@@ -1,0 +1,27 @@
+---
+- name: "Provision Open Stack Instance"
+  hosts: '{{ hosts | default("all") }}'
+  become: '{{ become | default("no") }}'
+  gather_facts: '{{ gather_facts | default("no") }}'
+  tasks:
+
+    - name: "provision a key pair"
+      os_keypair:
+        state: present
+        name: ansible_key
+      register: keypair_output
+
+    - name: "copy the keypair_output to a file"
+      copy:
+        content: keypair_output["private_key"]
+        dest: "~/.ssh/keypair_output.pem"
+
+    - name: "Create a new OpenShift instance on Virtual Machine"
+      os_server:
+        state: present
+        name: "{{ vm_name }}"
+        image: "{{ image }}"
+        key_name: ansible_key
+        flavor: "{{ flavor }}"
+        network: "{{ network }}"
+        security_groups: "{{ sec_groups }}"


### PR DESCRIPTION
The changes made are adding an Ansible playbook to automate the provisioning of an Open Stack Instance and a Reame.txt file which describes the playbook and how to run the playbook and setup the credentials. 
This playbook provides easier setup and saves time.