### PR TITLE
Do not remove .kube directory without setup_minishift

### DIFF
--- a/playbooks/roles/cleanup/tasks/cleanup.yml
+++ b/playbooks/roles/cleanup/tasks/cleanup.yml
@@ -5,10 +5,14 @@
 - name: "Stop minishift if running"
   shell: "{{ minishift_bin }} stop --profile {{ profile }}"
   ignore_errors: yes
+  when:
+    - setup_minishift|bool == true
 
 - name: "Delete minishift profile {{ profile }}"
   shell: "{{ minishift_bin }} delete --profile {{ profile }} --force"
   ignore_errors: yes
+  when:
+    - setup_minishift|bool == true
 
 - name: "Cleanup files and directories {{ minishift_dest_dir }}"
   file:
@@ -20,16 +24,25 @@
     - "README.adoc"
   ignore_errors: yes
 
-- name: "Cleanup certain files in {{ contra_env_setup_dir }}, kube config, and minishift profile"
+- name: "Cleanup certain files in {{ contra_env_setup_dir }}"
   file:
     path: "{{ item }}"
     state: absent
   with_items:
     - "{{ contra_env_setup_dir }}/.yml"
     - "{{ contra_env_setup_dir }}/.yaml"
+  ignore_errors: yes
+
+- name: "Cleanup certain files in kube config and minishift profile"
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
     - "{{ ansible_env.HOME }}/.minishift/profiles/{{ profile }}"
     - "{{ ansible_env.HOME }}/.kube"
   ignore_errors: yes
+  when:
+    - setup_minishift|bool == true
 
 # Determine if project directory exists
 - name: "Is project repository present in {{ project_dir }}"


### PR DESCRIPTION
Let say you already configure your cluster localy and have client
certificate for system:admin in ~/.kube/config and also session for
developer user which already accepted insecure connection to cluster.

Removing directory results in failure for "setup_minishift: false"

```
TASK [os_temps : Login to the Openshift cluster with a token] ******************************************
skipping: [localhost]

TASK [os_temps : Login to the Openshift cluster with a username and a password] ************************
fatal: [localhost]: FAILED! => {"changed": true, "cmd": ["/root/.minishift/cache/oc/v3.11.0/linux/oc", "
login", "", "--username=developer", "--password=developer", "--insecure-skip-tls-verify=true"], "delta":
 "0:00:00.166926", "end": "2020-09-09 07:13:59.272772", "msg": "non-zero return code", "rc": 1, "start":
 "2020-09-09 07:13:59.105846", "stderr": "error: tls: either ServerName or InsecureSkipVerify must be sp
ecified in the tls.Config", "stderr_lines": ["error: tls: either ServerName or InsecureSkipVerify must b
e specified in the tls.Config"], "stdout": "", "stdout_lines": []}

PLAY RECAP *********************************************************************************************
localhost                  : ok=25   changed=16   unreachable=0    failed=1    skipped=83   rescued=0    ignored=3
```